### PR TITLE
project.ymlをリファクタリング & iOS 18.0に更新

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,7 +1,7 @@
 name: Charalarm
 options:
   deploymentTarget:
-    iOS: 16.0
+    iOS: 18.0
 settings:
   base:
     MARKETING_VERSION: 3.4.4
@@ -40,13 +40,6 @@ schemes:
         CharalarmDevelop: all
     run:
       config: Debug
-    # test:
-    #   config: Debug
-    #   gatherCoverageData: false
-    #   targets:
-    #     - name: CharalarmTests
-    #       parallelizable: true
-    #       randomExecutionOrder: true
   Staging:
     build:
       targets:
@@ -60,11 +53,50 @@ schemes:
     run:
       config: Debug
 
-targets:
-  CharalarmDevelop:
+# 共通設定をYAML anchorsで定義
+_commonDependencies: &commonDependencies
+  - sdk: AdSupport.framework
+  - sdk: AppTrackingTransparency.framework
+  - sdk: StoreKit.framework
+  - package: Datadog
+    product: DatadogCore
+  - package: Datadog
+    product: DatadogLogs
+  - package: Firebase
+    product: FirebaseAnalytics
+  - package: Firebase
+    product: FirebaseAuth
+  - package: Firebase
+    product: FirebaseCrashlytics
+  - package: Firebase
+    product: FirebaseFirestore
+  - package: Firebase
+    product: FirebaseRemoteConfig
+  - package: KeychainAccess
+    product: KeychainAccess
+  - package: SDWebImageSwiftUI
+    product: SDWebImageSwiftUI
+  - package: Rswift
+    product: RswiftLibrary
+  - package: GoogleMobileAds
+    product: GoogleMobileAds
+
+_commonPlugins: &commonPlugins
+  - plugin: RswiftGenerateInternalResources
+    package: Rswift
+
+# ターゲットテンプレート
+targetTemplates:
+  CharalarmApp:
     type: application
     platform: iOS
     destinations: [iPhone]
+    dependencies: *commonDependencies
+    buildToolPlugins: *commonPlugins
+
+targets:
+  CharalarmDevelop:
+    templates: [CharalarmApp]
     sources:
       - path: Charalarm
         excludes:
@@ -78,10 +110,6 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.swiswiswift.sandbox.charalarm
         INFOPLIST_FILE: Charalarm/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon-Develop
-        # OTHER_LDFLAGS:
-        #   - $(inherited)
-        #   - $(OTHER_LDFLAGS)
-        #   - -ObjC
       configs:
         Debug:
           CODE_SIGN_ENTITLEMENTS: Charalarm/CharalarmDebug.entitlements
@@ -105,39 +133,9 @@ targets:
           DATADOG_CLIENT_TOKEN: pub2bd816c3d9d7157b4e1fd5febf77951f
           DATADOG_LOG_ENV: charalarm-development
           DATADOG_LOG_SERVICE: charalarm-development
-    dependencies:
-      - sdk: AdSupport.framework
-      - sdk: AppTrackingTransparency.framework
-      - sdk: StoreKit.framework
-      - package: Datadog
-        product: DatadogCore
-      - package: Datadog
-        product: DatadogLogs
-      - package: Firebase
-        product: FirebaseAnalytics
-      - package: Firebase
-        product: FirebaseAuth
-      - package: Firebase
-        product: FirebaseCrashlytics
-      - package: Firebase
-        product: FirebaseFirestore
-      - package: Firebase
-        product: FirebaseRemoteConfig
-      - package: KeychainAccess
-        product: KeychainAccess
-      - package: SDWebImageSwiftUI
-        product: SDWebImageSwiftUI
-      - package: Rswift
-        product: RswiftLibrary
-      - package: GoogleMobileAds
-        product: GoogleMobileAds
-    buildToolPlugins:
-      - plugin: RswiftGenerateInternalResources
-        package: Rswift
+
   CharalarmStaging:
-    type: application
-    platform: iOS
-    destinations: [iPhone]
+    templates: [CharalarmApp]
     sources:
       - path: Charalarm
         excludes:
@@ -151,10 +149,6 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.charalarm.staging
         INFOPLIST_FILE: Charalarm/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon-Staging
-        # OTHER_LDFLAGS:
-        #   - $(inherited)
-        #   - $(OTHER_LDFLAGS)
-        #   - -ObjC
       configs:
         Debug:
           CODE_SIGN_ENTITLEMENTS: Charalarm/CharalarmDebug.entitlements
@@ -178,45 +172,9 @@ targets:
           DATADOG_CLIENT_TOKEN: pub8e7e9ddd556eb859180ccad19517dd5c
           DATADOG_LOG_ENV: charalarm-staging
           DATADOG_LOG_SERVICE: charalarm-staging
-    dependencies:
-      - sdk: AdSupport.framework
-      - sdk: AppTrackingTransparency.framework
-      - sdk: StoreKit.framework
-      - package: Datadog
-        product: DatadogCore
-      - package: Datadog
-        product: DatadogLogs
-      - package: Firebase
-        product: FirebaseAnalytics
-      - package: Firebase
-        product: FirebaseAuth
-      - package: Firebase
-        product: FirebaseCrashlytics
-      - package: Firebase
-        product: FirebaseFirestore
-      - package: Firebase
-        product: FirebaseRemoteConfig
-      - package: KeychainAccess
-        product: KeychainAccess
-      - package: SDWebImageSwiftUI
-        product: SDWebImageSwiftUI
-      - package: Rswift
-        product: RswiftLibrary
-      - package: GoogleMobileAds
-        product: GoogleMobileAds
-    buildToolPlugins:
-      - plugin: RswiftGenerateInternalResources
-        package: Rswift
-    # preBuildScripts:
-    #   - script: ./Scripts/BuildPhases/rswift.sh
-    #     name: R.swift
-    #     basedOnDependencyAnalysis: false
-    #     outputFiles:
-    #       - $SRCROOT/Charalarm/Generated/R.generated.swift
+
   CharalarmProduction:
-    type: application
-    platform: iOS
-    destinations: [iPhone]
+    templates: [CharalarmApp]
     sources:
       - path: Charalarm
         excludes:
@@ -224,45 +182,12 @@ targets:
       - path: Charalarm/Resource
         type: folder
       - path: Config/Production
-    dependencies:
-      - sdk: AdSupport.framework
-      - sdk: AppTrackingTransparency.framework
-      - sdk: StoreKit.framework
-      - package: Datadog
-        product: DatadogCore
-      - package: Datadog
-        product: DatadogLogs
-      - package: Firebase
-        product: FirebaseAnalytics
-      - package: Firebase
-        product: FirebaseAuth
-      - package: Firebase
-        product: FirebaseCrashlytics
-      - package: Firebase
-        product: FirebaseFirestore
-      - package: Firebase
-        product: FirebaseRemoteConfig
-      - package: KeychainAccess
-        product: KeychainAccess
-      - package: SDWebImageSwiftUI
-        product: SDWebImageSwiftUI
-      - package: Rswift
-        product: RswiftLibrary
-      - package: GoogleMobileAds
-        product: GoogleMobileAds
-    buildToolPlugins:
-      - plugin: RswiftGenerateInternalResources
-        package: Rswift
     settings:
       base:
         CODE_SIGN_ENTITLEMENTS: Charalarm/CharalarmRelease.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: com.swiswiswift.CharacterAlarm
         INFOPLIST_FILE: Charalarm/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon-Production
-        # OTHER_LDFLAGS:
-        #   - $(inherited)
-        #   - $(OTHER_LDFLAGS)
-        #   - -ObjC
       configs:
         Debug:
           CODE_SIGN_ENTITLEMENTS: Charalarm/CharalarmDebug.entitlements
@@ -286,23 +211,3 @@ targets:
           DATADOG_CLIENT_TOKEN: pub746809c11c5291884508b5936605a3bf
           DATADOG_LOG_ENV: charalarm-production
           DATADOG_LOG_SERVICE: charalarm-production
-  # CharalarmTests:
-  #   type: bundle.unit-test
-  #   platform: iOS
-  #   sources:
-  #     - CharalarmTests
-  #   settings:
-  #     base:
-  #       INFOPLIST_FILE: CharalarmTests/Info.plist
-  #   dependencies:
-  #     - target: CharalarmDevelop
-  # CharalarmUITests:
-  #   type: bundle.ui-testing
-  #   platform: iOS
-  #   sources:
-  #     - CharalarmUITests
-  #   settings:
-  #     base:
-  #       INFOPLIST_FILE: CharalarmUITests/Info.plist
-  #   dependencies:
-  #     - target: CharalarmDevelop


### PR DESCRIPTION
## 概要
XcodeGenの設定ファイル（project.yml）をリファクタリングし、重複コードを大幅に削減。また、Minimum Deployment Targetを iOS 18.0 に更新しました。

## リファクタリング内容

### 1. targetTemplates の導入
共通設定を `CharalarmApp` テンプレートとして定義:
- `type: application`
- `platform: iOS`
- `destinations: [iPhone]`
- 依存関係
- ビルドプラグイン

### 2. YAML anchors による共通化
- `&commonDependencies`: 全ターゲットで共有する依存関係を一箇所に定義
- `&commonPlugins`: R.swiftプラグインを一箇所に定義

### 3. コード削減
- **309行 → 214行（95行削減、約31%削減）**
- 3ターゲット間の重複コードを大幅に削減
- メンテナンス性が向上

## その他の変更

### Deployment Target 更新
- iOS 16.0 → **iOS 18.0**
- 対応デバイス: iPhone XS 以降
- 最新のiOS APIを活用可能に

## 影響範囲
- project.ymlの構造変更（機能的には同等）
- 生成されるXcodeプロジェクトに変更なし
- 最小対応iOSバージョンが18.0に

## テスト
- [x] XcodeGen生成成功
- [x] Xcodeでプロジェクト開けることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)