### PR TITLE
Deploy(Dev)ワークフローを追加

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,110 @@
+name: Deploy(Dev)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'application/**'
+      - '.github/workflows/deploy-dev.yml'
+
+env:
+  AWS_ROLE_ARN: arn:aws:iam::448049807848:role/charalarm-github-action-role
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  test:
+    name: Test Application
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run tests
+        working-directory: application
+        run: make test
+
+  build-and-deploy:
+    name: Build & Deploy to Development
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-action-role-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure AWS profiles
+        run: |
+          mkdir -p ~/.aws
+          cp .github/workflows/aws_config/config ~/.aws/config
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push API image
+        working-directory: application
+        run: make build-api-image
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+
+      - name: Build and push Batch image
+        working-directory: application
+        run: make build-batch-image
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+
+      - name: Build and push Worker image
+        working-directory: application
+        run: make build-worker-image
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+
+      - name: Update Lambda functions
+        run: |
+          # Update API Lambda
+          aws lambda update-function-code \
+            --function-name charalarm-development-api \
+            --image-uri 448049807848.dkr.ecr.ap-northeast-1.amazonaws.com/charalarm-api:latest \
+            --region ${{ env.AWS_REGION }}
+
+          # Update Batch Lambda
+          aws lambda update-function-code \
+            --function-name charalarm-development-batch \
+            --image-uri 448049807848.dkr.ecr.ap-northeast-1.amazonaws.com/charalarm-batch:latest \
+            --region ${{ env.AWS_REGION }}
+
+          # Update Worker Lambda
+          aws lambda update-function-code \
+            --function-name charalarm-development-worker \
+            --image-uri 448049807848.dkr.ecr.ap-northeast-1.amazonaws.com/charalarm-worker:latest \
+            --region ${{ env.AWS_REGION }}
+
+      - name: Wait for Lambda updates to complete
+        run: |
+          echo "Waiting for Lambda functions to be updated..."
+          aws lambda wait function-updated --function-name charalarm-development-api --region ${{ env.AWS_REGION }}
+          aws lambda wait function-updated --function-name charalarm-development-batch --region ${{ env.AWS_REGION }}
+          aws lambda wait function-updated --function-name charalarm-development-worker --region ${{ env.AWS_REGION }}
+          echo "All Lambda functions updated successfully!"


### PR DESCRIPTION
## 概要
mainブランチへのpush時に自動的にdevelopment環境にデプロイするCDワークフローを追加しました。

## ワークフロー詳細

### トリガー
- mainブランチへのpush
- 対象パス: `application/**` または `.github/workflows/deploy-dev.yml`

### ジョブフロー

**1. Test**
- Go 1.24でテスト実行
- `make test` で全テストを実行

**2. Build & Deploy**
- テスト成功後に実行
- AWS認証（OIDC）
- Docker イメージビルド & ECRプッシュ:
  - `charalarm-api:latest`
  - `charalarm-batch:latest`
  - `charalarm-worker:latest`
- Lambda関数更新:
  - `charalarm-development-api`
  - `charalarm-development-batch`
  - `charalarm-development-worker`
- 更新完了待機

## メリット

✅ mainブランチへのマージ後、自動的にdevelopment環境にデプロイ
✅ 手動ビルド＆デプロイの手間を削減
✅ テスト失敗時はデプロイをスキップ
✅ デプロイの一貫性を確保

## 動作確認

このPRマージ後、次回のmainブランチへのpush時に自動デプロイが実行されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)