### PR TITLE
GitHub ActionsにLambda更新権限を追加

### DIFF
--- a/terraform/modules/github/iam.tf
+++ b/terraform/modules/github/iam.tf
@@ -43,6 +43,19 @@ data "aws_iam_policy_document" "charalarm_github_action_role_policy_document" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:UpdateFunctionCode",
+      "lambda:GetFunction",
+    ]
+    resources = [
+      "arn:aws:lambda:ap-northeast-1:448049807848:function:charalarm-development-*",
+      "arn:aws:lambda:ap-northeast-1:448049807848:function:charalarm-staging-*",
+      "arn:aws:lambda:ap-northeast-1:448049807848:function:charalarm-production-*",
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "charalarm_github_action_role_policy_attachment" {


### PR DESCRIPTION
## 問題

Deploy(Dev)ワークフローがLambda関数の更新で失敗していました。

エラー:
```
User is not authorized to perform: lambda:UpdateFunctionCode
```

## 原因

IAMロール `charalarm-github-action-role` に Lambda関数を更新する権限がありませんでした。

## 修正内容

GitHub Actions用のIAMロールに以下の権限を追加:
- ✅ `lambda:UpdateFunctionCode` - Lambda関数のコード更新
- ✅ `lambda:GetFunction` - Lambda関数の情報取得

対象リソース:
- `charalarm-development-*`
- `charalarm-staging-*`
- `charalarm-production-*`

## 次のステップ

1. このPRをマージ
2. Terraform apply で権限を適用
3. Deploy(Dev)ワークフローを再実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)