### PR TITLE
ビルドジョブをネイティブ ARM64 ランナーに変更 + 速度改善

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -161,17 +161,19 @@ jobs:
           aws lambda update-function-code \
             --function-name charalarm-api \
             --image-uri ${{ env.ECR_REGISTRY }}/charalarm-api:latest \
-            --region ${{ env.AWS_REGION }}
+            --region ${{ env.AWS_REGION }} &
 
           aws lambda update-function-code \
             --function-name batch-function2 \
             --image-uri ${{ env.ECR_REGISTRY }}/charalarm-batch:latest \
-            --region ${{ env.AWS_REGION }}
+            --region ${{ env.AWS_REGION }} &
 
           aws lambda update-function-code \
             --function-name worker-function2 \
             --image-uri ${{ env.ECR_REGISTRY }}/charalarm-worker:latest \
-            --region ${{ env.AWS_REGION }}
+            --region ${{ env.AWS_REGION }} &
+
+          wait
 
       - name: Wait for Lambda updates to complete
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -63,7 +63,7 @@ jobs:
   build-api:
     name: Build API Image
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       id-token: write
       contents: read
@@ -77,11 +77,6 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: github-action-role-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -95,7 +90,7 @@ jobs:
   build-batch:
     name: Build Batch Image
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       id-token: write
       contents: read
@@ -109,11 +104,6 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: github-action-role-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -127,7 +117,7 @@ jobs:
   build-worker:
     name: Build Worker Image
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       id-token: write
       contents: read
@@ -141,11 +131,6 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: github-action-role-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -175,7 +175,8 @@ jobs:
 
       - name: Wait for Lambda updates to complete
         run: |
-          aws lambda wait function-updated --function-name charalarm-api --region ${{ env.AWS_REGION }}
-          aws lambda wait function-updated --function-name batch-function2 --region ${{ env.AWS_REGION }}
-          aws lambda wait function-updated --function-name worker-function2 --region ${{ env.AWS_REGION }}
+          aws lambda wait function-updated --function-name charalarm-api --region ${{ env.AWS_REGION }} &
+          aws lambda wait function-updated --function-name batch-function2 --region ${{ env.AWS_REGION }} &
+          aws lambda wait function-updated --function-name worker-function2 --region ${{ env.AWS_REGION }} &
+          wait
           echo "All Lambda functions updated successfully!"

--- a/application/Makefile
+++ b/application/Makefile
@@ -14,12 +14,10 @@ test:
 .PHONY: build-api-image
 build-api-image:
 	aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin 448049807848.dkr.ecr.ap-northeast-1.amazonaws.com
-	docker buildx create --use --platform linux/arm64
-	docker buildx build --platform linux/arm64 -t charalarm/api:latest --load -f api/Dockerfile .
-	docker tag charalarm/api:latest ${API_REPOSITORY_URI}:latest
-	docker push ${API_REPOSITORY_URI}:latest
-	docker tag charalarm/api:latest ${API_REPOSITORY_URI}:${GITHUB_SHA}
-	docker push ${API_REPOSITORY_URI}:${GITHUB_SHA}
+	docker buildx build --platform linux/arm64 \
+		-t ${API_REPOSITORY_URI}:latest \
+		-t ${API_REPOSITORY_URI}:${GITHUB_SHA} \
+		--push -f api/Dockerfile .
 
 .PHONY: list-api-images
 list-api-images:
@@ -30,12 +28,10 @@ list-api-images:
 .PHONY: build-batch-image
 build-batch-image:
 	aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin 448049807848.dkr.ecr.ap-northeast-1.amazonaws.com
-	docker buildx create --use --platform linux/arm64
-	docker buildx build --platform linux/arm64 -t charalarm/batch:latest --load -f batch/Dockerfile .
-	docker tag charalarm/batch:latest ${BATCH_REPOSITORY_URI}:latest
-	docker push ${BATCH_REPOSITORY_URI}:latest
-	docker tag charalarm/batch:latest ${BATCH_REPOSITORY_URI}:${GITHUB_SHA}
-	docker push ${BATCH_REPOSITORY_URI}:${GITHUB_SHA}
+	docker buildx build --platform linux/arm64 \
+		-t ${BATCH_REPOSITORY_URI}:latest \
+		-t ${BATCH_REPOSITORY_URI}:${GITHUB_SHA} \
+		--push -f batch/Dockerfile .
 
 .PHONY: list-batch-images
 list-batch-images:
@@ -46,12 +42,10 @@ list-batch-images:
 .PHONY: build-worker-image
 build-worker-image:
 	aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin 448049807848.dkr.ecr.ap-northeast-1.amazonaws.com
-	docker buildx create --use --platform linux/arm64
-	docker buildx build --platform linux/arm64 -t charalarm/worker:latest --load -f worker/Dockerfile .
-	docker tag charalarm/worker:latest ${WORKER_REPOSITORY_URI}:latest
-	docker push ${WORKER_REPOSITORY_URI}:latest
-	docker tag charalarm/worker:latest ${WORKER_REPOSITORY_URI}:${GITHUB_SHA}
-	docker push ${WORKER_REPOSITORY_URI}:${GITHUB_SHA}
+	docker buildx build --platform linux/arm64 \
+		-t ${WORKER_REPOSITORY_URI}:latest \
+		-t ${WORKER_REPOSITORY_URI}:${GITHUB_SHA} \
+		--push -f worker/Dockerfile .
 
 .PHONY: list-worker-images
 list-worker-images:

--- a/application/Makefile
+++ b/application/Makefile
@@ -17,7 +17,7 @@ build-api-image:
 	docker buildx build --platform linux/arm64 \
 		-t ${API_REPOSITORY_URI}:latest \
 		-t ${API_REPOSITORY_URI}:${GITHUB_SHA} \
-		--push -f api/Dockerfile .
+		--provenance=false --push -f api/Dockerfile .
 
 .PHONY: list-api-images
 list-api-images:
@@ -31,7 +31,7 @@ build-batch-image:
 	docker buildx build --platform linux/arm64 \
 		-t ${BATCH_REPOSITORY_URI}:latest \
 		-t ${BATCH_REPOSITORY_URI}:${GITHUB_SHA} \
-		--push -f batch/Dockerfile .
+		--provenance=false --push -f batch/Dockerfile .
 
 .PHONY: list-batch-images
 list-batch-images:
@@ -45,7 +45,7 @@ build-worker-image:
 	docker buildx build --platform linux/arm64 \
 		-t ${WORKER_REPOSITORY_URI}:latest \
 		-t ${WORKER_REPOSITORY_URI}:${GITHUB_SHA} \
-		--push -f worker/Dockerfile .
+		--provenance=false --push -f worker/Dockerfile .
 
 .PHONY: list-worker-images
 list-worker-images:

--- a/application/api/Dockerfile
+++ b/application/api/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.24.0-alpine3.21 AS builder
 WORKDIR /app
-COPY .. .
+COPY . .
 RUN go mod tidy
-RUN CGE_ENABLE=0 GOOS=linux GOARCH=arm64 go build -o main api/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o main api/main.go
 
 
-FROM golang:1.24.0-alpine3.21
+FROM alpine:3.21
 
 WORKDIR /app
 COPY --from=builder /app/main .

--- a/application/batch/Dockerfile
+++ b/application/batch/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.24.0-alpine3.21 AS builder
 WORKDIR /app
 COPY . .
 RUN go mod tidy
-RUN CGE_ENABLE=0 GOOS=linux GOARCH=arm64 go build -o main batch/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o main batch/main.go
 
 FROM public.ecr.aws/lambda/provided:al2.2025.02.18.01
 COPY --from=builder /app/main ./main

--- a/application/worker/Dockerfile
+++ b/application/worker/Dockerfile
@@ -2,10 +2,10 @@ FROM golang:1.24.0-alpine3.21 AS builder
 WORKDIR /app
 COPY . .
 RUN go mod tidy
-RUN CGE_ENABLE=0 GOOS=linux GOARCH=arm64 go build -o main worker/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o main worker/main.go
 
 
-FROM --platform=linux/arm64 golang:1.24.0-alpine3.21
+FROM --platform=linux/arm64 alpine:3.21
 
 WORKDIR /app
 COPY --from=builder /app/main .


### PR DESCRIPTION
## Summary

- ビルドジョブ (API/Batch/Worker) のランナーを \`ubuntu-latest\` (x86_64) から \`ubuntu-24.04-arm\` (ネイティブ ARM64) に変更
- QEMU エミュレーションが不要になるため、\`Set up QEMU\` ステップを削除
- Docker イメージを \`--load\` + \`tag\` + \`push\` から \`--push\` 直接プッシュに変更 (ECR への push が 1 ステップに)
- Lambda コンテナのランタイムイメージを \`golang:1.24.0-alpine3.21\` → \`alpine:3.21\` に変更 (イメージサイズ削減)
- \`CGE_ENABLE=0\` → \`CGO_ENABLED=0\` タイポ修正 (api/batch/worker Dockerfile)
- Lambda wait を並列実行 (\`&\` + \`wait\`) に変更

ネイティブ ARM64 ランナーは 2026年1月からプライベートリポジトリでも利用可能になった。

## Test plan

- [ ] Deploy(Dev) ワークフローを手動実行して ARM64 イメージが正常にビルド・プッシュされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)