### PR TITLE
stg/prod デプロイワークフローを追加

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,55 @@
+name: Deploy(Prod)
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'デプロイするイメージタグ (Git SHA)'
+        required: true
+
+env:
+  AWS_ROLE_ARN: arn:aws:iam::986921280333:role/charalarm-prod-github-actions-role
+  AWS_REGION: ap-northeast-1
+  ECR_REGISTRY: 448049807848.dkr.ecr.ap-northeast-1.amazonaws.com
+
+jobs:
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-action-role-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update Lambda functions
+        run: |
+          aws lambda update-function-code \
+            --function-name charalarm-api \
+            --image-uri ${{ env.ECR_REGISTRY }}/charalarm-api:${{ github.event.inputs.image_tag }} \
+            --region ${{ env.AWS_REGION }} &
+
+          aws lambda update-function-code \
+            --function-name batch-function2 \
+            --image-uri ${{ env.ECR_REGISTRY }}/charalarm-batch:${{ github.event.inputs.image_tag }} \
+            --region ${{ env.AWS_REGION }} &
+
+          aws lambda update-function-code \
+            --function-name worker-function2 \
+            --image-uri ${{ env.ECR_REGISTRY }}/charalarm-worker:${{ github.event.inputs.image_tag }} \
+            --region ${{ env.AWS_REGION }} &
+
+          wait
+
+      - name: Wait for Lambda updates to complete
+        run: |
+          aws lambda wait function-updated --function-name charalarm-api --region ${{ env.AWS_REGION }} &
+          aws lambda wait function-updated --function-name batch-function2 --region ${{ env.AWS_REGION }} &
+          aws lambda wait function-updated --function-name worker-function2 --region ${{ env.AWS_REGION }} &
+          wait
+          echo "All Lambda functions updated successfully!"

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,0 +1,55 @@
+name: Deploy(Stg)
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'デプロイするイメージタグ (Git SHA)'
+        required: true
+
+env:
+  AWS_ROLE_ARN: arn:aws:iam::334832660826:role/charalarm-stg-github-actions-role
+  AWS_REGION: ap-northeast-1
+  ECR_REGISTRY: 448049807848.dkr.ecr.ap-northeast-1.amazonaws.com
+
+jobs:
+  deploy:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-action-role-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update Lambda functions
+        run: |
+          aws lambda update-function-code \
+            --function-name charalarm-api \
+            --image-uri ${{ env.ECR_REGISTRY }}/charalarm-api:${{ github.event.inputs.image_tag }} \
+            --region ${{ env.AWS_REGION }} &
+
+          aws lambda update-function-code \
+            --function-name batch-function2 \
+            --image-uri ${{ env.ECR_REGISTRY }}/charalarm-batch:${{ github.event.inputs.image_tag }} \
+            --region ${{ env.AWS_REGION }} &
+
+          aws lambda update-function-code \
+            --function-name worker-function2 \
+            --image-uri ${{ env.ECR_REGISTRY }}/charalarm-worker:${{ github.event.inputs.image_tag }} \
+            --region ${{ env.AWS_REGION }} &
+
+          wait
+
+      - name: Wait for Lambda updates to complete
+        run: |
+          aws lambda wait function-updated --function-name charalarm-api --region ${{ env.AWS_REGION }} &
+          aws lambda wait function-updated --function-name batch-function2 --region ${{ env.AWS_REGION }} &
+          aws lambda wait function-updated --function-name worker-function2 --region ${{ env.AWS_REGION }} &
+          wait
+          echo "All Lambda functions updated successfully!"

--- a/terraform/environment/production/github_oidc.tf
+++ b/terraform/environment/production/github_oidc.tf
@@ -1,0 +1,38 @@
+# GitHub Actions OIDC プロバイダー
+# OIDC プロバイダーは AWS アカウントに1つしか作れないため、
+# このモジュールはアカウントにつき1回だけ使用すること
+module "github_oidc" {
+  source = "../../modules/github_oidc"
+
+  tags = {
+    Name    = "github-actions-oidc-provider"
+    Project = "charalarm"
+  }
+}
+
+# GitHub Actions に付与する権限を定義する
+# Lambda のイメージ更新に必要な権限のみを最小限で付与する
+# stg/prod はイメージビルドを行わないため ECR 権限は不要
+data "aws_iam_policy_document" "github_actions_deploy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:UpdateFunctionCode",
+      "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
+    ]
+    resources = ["*"]
+  }
+}
+
+# GitHub Actions デプロイロール
+# role_arn は GitHub Actions ワークフローの role-to-assume に設定する
+module "github_actions_deploy_role" {
+  source = "../../modules/github_actions_role"
+
+  oidc_provider_arn = module.github_oidc.oidc_provider_arn
+  github_repository = "takoikatakotako/charalarm"
+  role_name         = "charalarm-prod-github-actions-role"
+  policy_name       = "charalarm-prod-github-actions-policy"
+  policy_json       = data.aws_iam_policy_document.github_actions_deploy.json
+}

--- a/terraform/environment/staging/github_oidc.tf
+++ b/terraform/environment/staging/github_oidc.tf
@@ -1,0 +1,38 @@
+# GitHub Actions OIDC プロバイダー
+# OIDC プロバイダーは AWS アカウントに1つしか作れないため、
+# このモジュールはアカウントにつき1回だけ使用すること
+module "github_oidc" {
+  source = "../../modules/github_oidc"
+
+  tags = {
+    Name    = "github-actions-oidc-provider"
+    Project = "charalarm"
+  }
+}
+
+# GitHub Actions に付与する権限を定義する
+# Lambda のイメージ更新に必要な権限のみを最小限で付与する
+# stg/prod はイメージビルドを行わないため ECR 権限は不要
+data "aws_iam_policy_document" "github_actions_deploy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:UpdateFunctionCode",
+      "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
+    ]
+    resources = ["*"]
+  }
+}
+
+# GitHub Actions デプロイロール
+# role_arn は GitHub Actions ワークフローの role-to-assume に設定する
+module "github_actions_deploy_role" {
+  source = "../../modules/github_actions_role"
+
+  oidc_provider_arn = module.github_oidc.oidc_provider_arn
+  github_repository = "takoikatakotako/charalarm"
+  role_name         = "charalarm-stg-github-actions-role"
+  policy_name       = "charalarm-stg-github-actions-policy"
+  policy_json       = data.aws_iam_policy_document.github_actions_deploy.json
+}


### PR DESCRIPTION
## Summary

- \`deploy-stg.yml\` / \`deploy-prod.yml\` を新規追加
  - \`workflow_dispatch\` で \`image_tag\` (Git SHA) を入力してデプロイ
  - ビルドなし、Lambda の image URI 更新のみ
  - 3 関数の update / wait を並列実行
- \`terraform/environment/staging/github_oidc.tf\` を新規追加
  - staging アカウント (334832660826) に GitHub Actions OIDC プロバイダーと IAM ロールを作成
- \`terraform/environment/production/github_oidc.tf\` を新規追加
  - production アカウント (986921280333) に GitHub Actions OIDC プロバイダーと IAM ロールを作成

stg/prod はイメージビルドを行わないため ECR 権限は不要。Lambda 更新権限のみ付与。

## デプロイフロー

```
1. deploy-dev.yml で main push → dev にデプロイ & ECR に :sha タグでイメージ保存
2. deploy-stg.yml を手動実行 → image_tag に SHA を入力 → stg にデプロイ
3. deploy-prod.yml を手動実行 → image_tag に SHA を入力 → prod にデプロイ
```

## Test plan

- [ ] staging/production 各アカウントで `terraform apply` を実行して OIDC + Role を作成
- [ ] deploy-stg.yml を手動実行して stg へのデプロイが成功することを確認
- [ ] deploy-prod.yml を手動実行して prod へのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)