### PR TITLE
staging環境のdeprecatedリソース(charalarm.swiswiswift.com)を削除

### DIFF
--- a/terraform/environment/staging/.terraform.lock.hcl
+++ b/terraform/environment/staging/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f9f51b17f2978394954e9f6ab9ef293b8e11f1443117294ccf87f7f8212b3439",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.2.1"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environment/staging/main.tf
+++ b/terraform/environment/staging/main.tf
@@ -126,30 +126,6 @@ module "dynamodb" {
 }
 
 
-##############################################################
-# Deprecated
-##############################################################
-module "web_api" {
-  source                    = "../../modules/web_api"
-  domain                    = local.api_domain
-  route53_zone_id           = local.route53_zone_id
-  acm_certificate_arn       = local.api_acm_certificate_arn
-  application_version       = local.application_version
-  application_bucket_name   = local.application_bucket_name
-  resource_domain           = local.resource_domain
-  datadog_log_forwarder_arn = local.datadog_log_forwarder_arn
-}
-
-
-module "resource" {
-  source              = "../../modules/resource"
-  bucket_name         = local.resource_bucket_name
-  acm_certificate_arn = local.resource_acm_certificate_arn
-  domain              = local.resource_domain
-  zone_id             = local.route53_zone_id
-}
-
-
 module "datadog" {
   source     = "../../modules/datadog"
   dd_api_key = local.dd_api_key

--- a/terraform/environment/staging/variables.tf
+++ b/terraform/environment/staging/variables.tf
@@ -8,19 +8,6 @@ locals {
   api_record_name2 = "api"
 
 
-  // deprecatec?
-  aws_profile                        = "charalarm-staging"
-  route53_zone_id                    = "Z1001429NNWJ0CTVGUIG"
-  api_domain                         = "api.charalarm.swiswiswift.com"
-  api_acm_certificate_arn            = "arn:aws:acm:ap-northeast-1:334832660826:certificate/05220010-3029-4b61-827a-fac783808a8c"
-  application_version                = "0.0.1"
-  application_bucket_name            = "application.charalarm.swiswiswift.com"
-  lp_domain                          = "charalarm.swiswiswift.com"
-  lp_bucket_name                     = "charalarm.swiswiswift.com"
-  lp_acm_certificate_arn             = "arn:aws:acm:us-east-1:334832660826:certificate/92021af4-b3ae-4d21-96b8-fc8736b9c1e1"
-  resource_domain                    = "resource.charalarm.swiswiswift.com"
-  resource_bucket_name               = "resource.charalarm.swiswiswift.com"
-  resource_acm_certificate_arn       = "arn:aws:acm:us-east-1:334832660826:certificate/cbd20721-8637-4079-9843-37169da6daa9"
   ios_voip_push_certificate_filename = "staging-voip-expiration-20260408-certificate.pem"
   ios_voip_push_private_filename     = "staging-voip-expiration-20260408-privatekey.pem"
   datadog_log_forwarder_arn          = "arn:aws:lambda:ap-northeast-1:334832660826:function:datadog-forwarder"


### PR DESCRIPTION
## Summary

- `charalarm.swiswiswift.com` に紐づく deprecated な Terraform モジュール (`web_api`, `resource`) を staging 環境から削除
- 対応する deprecated 変数を `variables.tf` から削除
- S3バケット・API Gateway 等 229 リソースを削除済み
- Route 53 ホストゾーン (`charalarm.swiswiswift.com`) も手動削除済み

## Test plan

- [x] `terraform plan` で `web_api` / `resource` モジュール以外への影響がないことを確認
- [x] `terraform apply` が正常完了 (229 destroy)
- [x] 再度 `terraform apply` で `No changes.` を確認
- [x] iOS アプリは `charalarm-staging.swiswiswift.com` を使用しており影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)