### PR TITLE
デプロイ時に環境タグ(dev/stg/prod)をECRイメージに付与

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -182,3 +182,17 @@ jobs:
           aws lambda wait function-updated --function-name worker-function2 --region ${{ env.AWS_REGION }} &
           wait
           echo "All Lambda functions updated successfully!"
+
+      - name: Tag images as dev
+        run: |
+          for REPO in charalarm-api charalarm-batch charalarm-worker; do
+            MANIFEST=$(aws ecr batch-get-image \
+              --repository-name $REPO \
+              --image-ids imageTag=${{ github.sha }} \
+              --query 'images[].imageManifest' \
+              --output text)
+            aws ecr put-image \
+              --repository-name $REPO \
+              --image-tag dev \
+              --image-manifest "$MANIFEST"
+          done

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -53,3 +53,17 @@ jobs:
           aws lambda wait function-updated --function-name worker-function2 --region ${{ env.AWS_REGION }} &
           wait
           echo "All Lambda functions updated successfully!"
+
+      - name: Tag images as prod
+        run: |
+          for REPO in charalarm-api charalarm-batch charalarm-worker; do
+            MANIFEST=$(aws ecr batch-get-image \
+              --repository-name $REPO \
+              --image-ids imageTag=${{ github.event.inputs.image_tag }} \
+              --query 'images[].imageManifest' \
+              --output text)
+            aws ecr put-image \
+              --repository-name $REPO \
+              --image-tag prod \
+              --image-manifest "$MANIFEST"
+          done

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -53,3 +53,17 @@ jobs:
           aws lambda wait function-updated --function-name worker-function2 --region ${{ env.AWS_REGION }} &
           wait
           echo "All Lambda functions updated successfully!"
+
+      - name: Tag images as stg
+        run: |
+          for REPO in charalarm-api charalarm-batch charalarm-worker; do
+            MANIFEST=$(aws ecr batch-get-image \
+              --repository-name $REPO \
+              --image-ids imageTag=${{ github.event.inputs.image_tag }} \
+              --query 'images[].imageManifest' \
+              --output text)
+            aws ecr put-image \
+              --repository-name $REPO \
+              --image-tag stg \
+              --image-manifest "$MANIFEST"
+          done


### PR DESCRIPTION
## Summary

- `deploy-dev.yml`: デプロイ完了後に `dev` タグを付与
- `deploy-stg.yml`: デプロイ完了後に `stg` タグを付与
- `deploy-prod.yml`: デプロイ完了後に `prod` タグを付与

ECR を見れば各環境にどのイメージがデプロイされているか一目で確認できるようになる

## Test plan

- [ ] `deploy-dev.yml` 実行後、ECR の `charalarm-api`, `charalarm-batch`, `charalarm-worker` に `dev` タグが付いていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)