### PR TITLE
ECRタグ付けに--registry-idを追加

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -187,11 +187,13 @@ jobs:
         run: |
           for REPO in charalarm-api charalarm-batch charalarm-worker; do
             MANIFEST=$(aws ecr batch-get-image \
+              --registry-id 448049807848 \
               --repository-name $REPO \
               --image-ids imageTag=${{ github.sha }} \
               --query 'images[].imageManifest' \
               --output text)
             aws ecr put-image \
+              --registry-id 448049807848 \
               --repository-name $REPO \
               --image-tag dev \
               --image-manifest "$MANIFEST"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -58,11 +58,13 @@ jobs:
         run: |
           for REPO in charalarm-api charalarm-batch charalarm-worker; do
             MANIFEST=$(aws ecr batch-get-image \
+              --registry-id 448049807848 \
               --repository-name $REPO \
               --image-ids imageTag=${{ github.event.inputs.image_tag }} \
               --query 'images[].imageManifest' \
               --output text)
             aws ecr put-image \
+              --registry-id 448049807848 \
               --repository-name $REPO \
               --image-tag prod \
               --image-manifest "$MANIFEST"

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -58,11 +58,13 @@ jobs:
         run: |
           for REPO in charalarm-api charalarm-batch charalarm-worker; do
             MANIFEST=$(aws ecr batch-get-image \
+              --registry-id 448049807848 \
               --repository-name $REPO \
               --image-ids imageTag=${{ github.event.inputs.image_tag }} \
               --query 'images[].imageManifest' \
               --output text)
             aws ecr put-image \
+              --registry-id 448049807848 \
               --repository-name $REPO \
               --image-tag stg \
               --image-manifest "$MANIFEST"


### PR DESCRIPTION
## Summary

- `batch-get-image` / `put-image` で `--registry-id 448049807848` を指定するよう修正
- クロスアカウントECR へのアクセス時にレジストリIDを省略していたため `AccessDeniedException` が発生していた

## Test plan

- [x] `deploy-dev.yml` を手動実行して全ジョブが成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)