### PR TITLE
list-imagesワークフローを修正

### DIFF
--- a/.github/workflows/list-images.yml
+++ b/.github/workflows/list-images.yml
@@ -1,10 +1,11 @@
-name: List Imagess
+name: List Images
 
 on:
   workflow_dispatch:
 
 env:
-  AWS_ROLE_ARN: arn:aws:iam::448049807848:role/charalarm-github-action-role
+  AWS_ROLE_ARN: arn:aws:iam::039612872248:role/charalarm-dev-github-actions-role
+  AWS_REGION: ap-northeast-1
 
 jobs:
   list_images:
@@ -17,26 +18,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: configure aws credentials
+    - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.AWS_ROLE_ARN }}
         role-session-name: github-action-role-${{ github.run_id }}
-        aws-region: ap-northeast-1
+        aws-region: ${{ env.AWS_REGION }}
 
-    - name: configure aws profiles
-      run: |
-        mkdir ~/.aws
-        cp .github/workflows/aws_config/config ~/.aws/config
-
-    - name: list api images
+    - name: List API images
       working-directory: application
       run: make list-api-images
 
-    - name: list batch images
+    - name: List Batch images
       working-directory: application
       run: make list-batch-images
 
-    - name: list worker images
+    - name: List Worker images
       working-directory: application
       run: make list-worker-images

--- a/.github/workflows/list-images.yml
+++ b/.github/workflows/list-images.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_ROLE_ARN: arn:aws:iam::039612872248:role/charalarm-dev-github-actions-role
+  AWS_ROLE_ARN: arn:aws:iam::448049807848:role/charalarm-management-github-actions-role
   AWS_REGION: ap-northeast-1
 
 jobs:

--- a/application/Makefile
+++ b/application/Makefile
@@ -21,7 +21,7 @@ build-api-image:
 
 .PHONY: list-api-images
 list-api-images:
-	aws ecr list-images --repository-name charalarm-api --output table
+	aws ecr list-images --registry-id 448049807848 --repository-name charalarm-api --output table
 
 
 # Batch
@@ -35,7 +35,7 @@ build-batch-image:
 
 .PHONY: list-batch-images
 list-batch-images:
-	aws ecr list-images --repository-name charalarm-batch --output table
+	aws ecr list-images --registry-id 448049807848 --repository-name charalarm-batch --output table
 
 
 # Worker
@@ -49,4 +49,4 @@ build-worker-image:
 
 .PHONY: list-worker-images
 list-worker-images:
-	aws ecr list-images --repository-name charalarm-worker --output table
+	aws ecr list-images --registry-id 448049807848 --repository-name charalarm-worker --output table

--- a/terraform/environment/development/github_oidc.tf
+++ b/terraform/environment/development/github_oidc.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
     resources = ["*"]
   }
 
-  # ECR イメージのプッシュ
+  # ECR イメージのプッシュ・取得
   statement {
     effect = "Allow"
     actions = [
@@ -44,6 +44,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "ecr:InitiateLayerUpload",
       "ecr:UploadLayerPart",
       "ecr:CompleteLayerUpload",
+      "ecr:ListImages",
     ]
     resources = [
       "arn:aws:ecr:ap-northeast-1:448049807848:repository/charalarm-api",

--- a/terraform/environment/management/github_oidc.tf
+++ b/terraform/environment/management/github_oidc.tf
@@ -1,0 +1,36 @@
+module "github_oidc" {
+  source = "../../modules/github_oidc"
+
+  tags = {
+    Name    = "github-actions-oidc-provider"
+    Project = "charalarm"
+  }
+}
+
+# GitHub Actions に付与する権限を定義する
+# ECR イメージ一覧の取得に必要な権限を付与する
+data "aws_iam_policy_document" "github_actions_list_images" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:ListImages",
+    ]
+    resources = [
+      "arn:aws:ecr:ap-northeast-1:448049807848:repository/charalarm-api",
+      "arn:aws:ecr:ap-northeast-1:448049807848:repository/charalarm-batch",
+      "arn:aws:ecr:ap-northeast-1:448049807848:repository/charalarm-worker",
+    ]
+  }
+}
+
+# GitHub Actions デプロイロール
+# role_arn は GitHub Actions ワークフローの role-to-assume に設定する
+module "github_actions_list_images_role" {
+  source = "../../modules/github_actions_role"
+
+  oidc_provider_arn = module.github_oidc.oidc_provider_arn
+  github_repository = "takoikatakotako/charalarm"
+  role_name         = "charalarm-management-github-actions-role"
+  policy_name       = "charalarm-management-github-actions-policy"
+  policy_json       = data.aws_iam_policy_document.github_actions_list_images.json
+}

--- a/terraform/modules/repository/main.tf
+++ b/terraform/modules/repository/main.tf
@@ -28,6 +28,7 @@ data "aws_iam_policy_document" "policy_document" {
       "ecr:InitiateLayerUpload",
       "ecr:UploadLayerPart",
       "ecr:CompleteLayerUpload",
+      "ecr:ListImages",
       "ecr:SetRepositoryPolicy",
       "ecr:GetRepositoryPolicy",
       "ecr:DeleteRepositoryPolicy"


### PR DESCRIPTION
## Summary

- ワークフロー名のタイポを修正 (`List Imagess` → `List Images`)
- ロールを management アカウントの専用ロール (`charalarm-management-github-actions-role`) に変更
- 古いロールと不要な `configure aws profiles` ステップを削除し OIDC 認証に統一
- Makefile の `list-*-images` に `--registry-id 448049807848` を追加 (クロスアカウントECRアクセス)
- management アカウントに GitHub OIDC ロールを作成 (`terraform/environment/management/github_oidc.tf`)
- dev IAM ポリシーと ECR リポジトリポリシーに `ecr:ListImages` を追加

## Test plan

- [x] ワークフローを手動実行して全ジョブ成功を確認 (management ロール使用)
- [x] `dev` タグが ECR イメージ一覧に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)