### PR TITLE
iOS: force-unwrap クラッシュ修正とエラーメッセージ適切化

### DIFF
--- a/ios/Charalarm/Localizable.xcstrings
+++ b/ios/Charalarm/Localizable.xcstrings
@@ -33,9 +33,6 @@
     "%@のボイス" : {
 
     },
-    "aaa" : {
-
-    },
     "alarm-add-alarm" : {
       "localizations" : {
         "en" : {
@@ -98,6 +95,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アラーム編集"
+          }
+        }
+      }
+    },
+    "alarm-failed-to-delete-the-alarm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to delete the alarm."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アラームの削除に失敗しました。"
           }
         }
       }
@@ -1946,9 +1960,6 @@
 
     },
     "ランダム" : {
-
-    },
-    "動画見てください！" : {
 
     },
     "送信" : {

--- a/ios/Charalarm/Repository/APIRepository.swift
+++ b/ios/Charalarm/Repository/APIRepository.swift
@@ -1,11 +1,15 @@
 import Foundation
 
+enum APIRepositoryError: Error {
+    case invalidURL
+}
+
 struct APIRepository {}
 
 extension APIRepository {
     func postPushTokenAddPushToken(userID: String, authToken: String, pushToken: PushTokenRequest) async throws {
         let path = "/push-token/ios/push/add"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader: [String: String] = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Encodable = pushToken
         let _: MessageResponse = try await APIClient().request(url: url, httpMethod: .post, requestHeader: requestHeader, requestBody: requestBody)
@@ -13,7 +17,7 @@ extension APIRepository {
 
     func postPushTokenAddVoIPPushToken(userID: String, authToken: String, pushToken: PushTokenRequest) async throws {
         let path = "/push-token/ios/voip-push/add"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader: [String: String] = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Encodable = pushToken
         let _: MessageResponse = try await APIClient().request(url: url, httpMethod: .post, requestHeader: requestHeader, requestBody: requestBody)
@@ -23,7 +27,7 @@ extension APIRepository {
 extension APIRepository {
     func getUserInfo(userID: String, authToken: String) async throws -> UserInfo {
         let path = "/user/info"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Encodable? = nil
         let userInfoResponse: UserInfoResponse = try await APIClient().request(url: url, httpMethod: .get, requestHeader: requestHeader, requestBody: requestBody)
@@ -45,7 +49,7 @@ extension APIRepository {
 
     func postUserUpdatePremium(userID: String, authToken: String, requestBody: UserUpdatePremiumPlanRequest) async throws {
         let path = "/user/update-premium"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader: [String: String] = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Encodable? = requestBody
         let _: MessageResponse = try await APIClient().request(url: url, httpMethod: .post, requestHeader: requestHeader, requestBody: requestBody)
@@ -53,7 +57,7 @@ extension APIRepository {
 
     func postUserSignup(request: UserSignUpRequest) async throws {
         let path = "/user/signup"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader: [String: String] = APIHeader.defaultHeader
         let requestBody: Encodable? = request
         let _: MessageResponse = try await APIClient().request(url: url, httpMethod: .post, requestHeader: requestHeader, requestBody: requestBody)
@@ -61,7 +65,7 @@ extension APIRepository {
 
     func postUserWithdraw(userID: String, authToken: String) async throws {
         let path = "/user/withdraw"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader: [String: String] = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Encodable? = nil
         let _: MessageResponse = try await APIClient().request(url: url, httpMethod: .post, requestHeader: requestHeader, requestBody: requestBody)
@@ -71,7 +75,7 @@ extension APIRepository {
 extension APIRepository {
     func getCharaList() async throws -> [Chara] {
         let path = "/chara/list"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader: [String: String] = APIHeader.defaultHeader
         let requestBody: Encodable? = nil
         let charaResponses: [CharaResponse] = try await APIClient().request(url: url, httpMethod: .get, requestHeader: requestHeader, requestBody: requestBody)
@@ -80,7 +84,7 @@ extension APIRepository {
 
     func fetchCharacter(charaID: String) async throws -> Chara {
         let path = "/chara/id/\(charaID)"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader: [String: String] = APIHeader.defaultHeader
         let requestBody: Encodable? = nil
         let charaResponse: CharaResponse = try await APIClient().request(url: url, httpMethod: .get, requestHeader: requestHeader, requestBody: requestBody)
@@ -91,7 +95,7 @@ extension APIRepository {
 extension APIRepository {
     func fetchMaintenance() async throws -> Bool {
         let path = "/maintenance"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader = APIHeader.defaultHeader
         let requestBody: Request? = nil
         let response: MaintenanceResponse = try await APIClient().request(url: url, httpMethod: .get, requestHeader: requestHeader, requestBody: requestBody)
@@ -100,7 +104,7 @@ extension APIRepository {
 
     func fetchRequireVersion() async throws -> String {
         let path = "/require"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader = APIHeader.defaultHeader
         let requestBody: Request? = nil
         let response: RequireVersionResponse = try await APIClient().request(url: url, httpMethod: .get, requestHeader: requestHeader, requestBody: requestBody)
@@ -111,7 +115,7 @@ extension APIRepository {
 extension APIRepository {
     func fetchAlarms(userID: String, authToken: String) async throws -> [AlarmResponse] {
         let path = "/alarm/list"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Request? = nil
         return try await APIClient().request(url: url, httpMethod: .get, requestHeader: requestHeader, requestBody: requestBody)
@@ -119,7 +123,7 @@ extension APIRepository {
 
     func addAlarm(userID: String, authToken: String, requestBody: AlarmAddRequest) async throws {
         let path = "/alarm/add"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Request? = requestBody
         let _: MessageResponse = try await APIClient().request(url: url, httpMethod: .post, requestHeader: requestHeader, requestBody: requestBody)
@@ -127,7 +131,7 @@ extension APIRepository {
 
     func editAlarm(userID: String, authToken: String, requestBody: AlarmEditRequest) async throws {
         let path = "/alarm/edit"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Request? = requestBody
         let _: MessageResponse = try await APIClient().request(url: url, httpMethod: .post, requestHeader: requestHeader, requestBody: requestBody)
@@ -135,9 +139,20 @@ extension APIRepository {
 
     func deleteAlarm(userID: String, authToken: String, requestBody: AlarmDeleteRequest) async throws {
         let path = "/alarm/delete"
-        let url = URL(string: Variables.apiEndpoint + path)!
+        let url = try createURL(path: path)
         let requestHeader = APIHeader.createAuthorizationRequestHeader(userID: userID, authToken: authToken)
         let requestBody: Request? = requestBody
         let _: MessageResponse = try await APIClient().request(url: url, httpMethod: .post, requestHeader: requestHeader, requestBody: requestBody)
+    }
+}
+
+// MARK: - Private
+
+private extension APIRepository {
+    func createURL(path: String) throws -> URL {
+        guard let url = URL(string: Variables.apiEndpoint + path) else {
+            throw APIRepositoryError.invalidURL
+        }
+        return url
     }
 }

--- a/ios/Charalarm/Repository/APIRequest.swift
+++ b/ios/Charalarm/Repository/APIRequest.swift
@@ -9,9 +9,7 @@ struct APIHeader {
     static let defaultHeader: [String: String] = ["Content-Type": "application/json"]
 
     static func createAuthorizationRequestHeader(userID: String, authToken: String) -> [String: String] {
-        guard let authorization = "\(userID):\(authToken)".data(using: .utf8)?.base64EncodedString() else {
-            fatalError()
-        }
+        let authorization = Data("\(userID):\(authToken)".utf8).base64EncodedString()
         var requestHeader = Self.defaultHeader
         requestHeader["Authorization"] = "Basic \(authorization)"
         return requestHeader
@@ -19,16 +17,20 @@ struct APIHeader {
 }
 
 struct APIRequest {
-    static func createUrlRequest(baseUrl: String = Variables.apiEndpoint, path: String, httpMethod: HttpMethod = .get, requestHeader: [String: String] = ["X-API-VERSION": "0", "Content-Type": "application/json"]) -> URLRequest {
-        let url = URL(string: baseUrl + path)!
+    static func createUrlRequest(baseUrl: String = Variables.apiEndpoint, path: String, httpMethod: HttpMethod = .get, requestHeader: [String: String] = ["X-API-VERSION": "0", "Content-Type": "application/json"]) throws -> URLRequest {
+        guard let url = URL(string: baseUrl + path) else {
+            throw APIRepositoryError.invalidURL
+        }
         var request = URLRequest(url: url)
         request.httpMethod = httpMethod.rawValue
         request.allHTTPHeaderFields = requestHeader
         return request
     }
 
-    static func createUrlRequest<RequestBody: Encodable>(baseUrl: String = Variables.apiEndpoint, path: String, httpMethod: HttpMethod = .get, requestHeader: [String: String] = ["X-API-VERSION": "0", "Content-Type": "application/json"], requestBody: RequestBody) -> URLRequest {
-        let url = URL(string: Variables.apiEndpoint + path)!
+    static func createUrlRequest<RequestBody: Encodable>(baseUrl: String = Variables.apiEndpoint, path: String, httpMethod: HttpMethod = .get, requestHeader: [String: String] = ["X-API-VERSION": "0", "Content-Type": "application/json"], requestBody: RequestBody) throws -> URLRequest {
+        guard let url = URL(string: Variables.apiEndpoint + path) else {
+            throw APIRepositoryError.invalidURL
+        }
         var request = URLRequest(url: url)
         request.httpMethod = httpMethod.rawValue
         request.allHTTPHeaderFields = requestHeader

--- a/ios/Charalarm/View/AlarmDetail/AlarmDetailViewState.swift
+++ b/ios/Charalarm/View/AlarmDetail/AlarmDetailViewState.swift
@@ -32,7 +32,8 @@ import Combine
     }
 
     var alarmTimeString: String {
-        return "\(String(format: "%02d", alarm.hour)):\(String(format: "%02d", alarm.minute))(GMT+\("9"))"
+        let sign = alarm.timeDifference >= 0 ? "+" : "-"
+        return "\(String(format: "%02d", alarm.hour)):\(String(format: "%02d", alarm.minute))(GMT\(sign)\(abs(alarm.timeDifference)))"
     }
 
     init(alarm: Alarm, type: AlarmDetailViewTyep) {
@@ -80,7 +81,7 @@ import Combine
     func deleteAlarm() {
         guard let userID = keychainRepository.getUserID(),
               let authToken = keychainRepository.getAuthToken() else {
-            self.alertMessage = "不明なエラーです（UserDefaultsに匿名ユーザー名とかがない）"
+            self.alertMessage = String(localized: "error-failed-to-get-authentication-information")
             self.showingAlert = true
             return
         }
@@ -92,7 +93,7 @@ import Combine
                 dismissSubject.send()
                 showingIndicator = false
             } catch {
-                self.alertMessage = "xyz"
+                self.alertMessage = String(localized: "alarm-failed-to-delete-the-alarm")
                 self.showingAlert = true
             }
         }
@@ -134,21 +135,26 @@ import Combine
     private func createAlarm() {
         guard let userID = keychainRepository.getUserID(),
               let authToken = keychainRepository.getAuthToken() else {
-            alertMessage = "Error"
+            alertMessage = String(localized: "error-failed-to-get-authentication-information")
+            showingAlert = true
+            return
+        }
+        guard let userUUID = UUID(uuidString: userID) else {
+            alertMessage = String(localized: "error-failed-to-get-authentication-information")
             showingAlert = true
             return
         }
         Task { @MainActor in
             showingIndicator = true
             do {
-                let alarmRequest = alarm.toAlarmRequest(userID: UUID(uuidString: userID)!)
+                let alarmRequest = alarm.toAlarmRequest(userID: userUUID)
                 let alarmAddRequest = AlarmAddRequest(alarm: alarmRequest)
                 try await apiRepository.addAlarm(userID: userID, authToken: authToken, requestBody: alarmAddRequest)
                 dismissSubject.send()
                 showingIndicator = false
             } catch {
-                print(error)
-                alertMessage = "Error"
+                CharalarmLogger.error("failed to create alarm, file: \(#file), line: \(#line)", error: error)
+                alertMessage = String(localized: "alarm-failed-to-create-an-alarm")
                 showingAlert = true
             }
         }
@@ -157,20 +163,25 @@ import Combine
     private func editAlarm() {
         guard let userID = keychainRepository.getUserID(),
               let authToken = keychainRepository.getAuthToken() else {
-            alertMessage = "不明なエラーです（UserDefaultsに匿名ユーザー名とかがない）"
+            alertMessage = String(localized: "error-failed-to-get-authentication-information")
+            showingAlert = true
+            return
+        }
+        guard let userUUID = UUID(uuidString: userID) else {
+            alertMessage = String(localized: "error-failed-to-get-authentication-information")
             showingAlert = true
             return
         }
         Task { @MainActor in
             showingIndicator = true
             do {
-                let alarmRequest = alarm.toAlarmRequest(userID: UUID(uuidString: userID)!)
+                let alarmRequest = alarm.toAlarmRequest(userID: userUUID)
                 let alarmEditRequest = AlarmEditRequest(alarm: alarmRequest)
                 try await apiRepository.editAlarm(userID: userID, authToken: authToken, requestBody: alarmEditRequest)
                 dismissSubject.send()
                 showingIndicator = false
             } catch {
-                alertMessage = "Error"
+                alertMessage = String(localized: "alarm-failed-to-edit-the-alarm")
                 showingAlert = true
             }
         }

--- a/ios/Charalarm/View/AlarmList/AlarmListViewState.swift
+++ b/ios/Charalarm/View/AlarmList/AlarmListViewState.swift
@@ -91,6 +91,7 @@ import Foundation
                 let pushToken = PushTokenRequest(pushToken: Variables.shared.voipPushToken)
                 try await apiRepository.postPushTokenAddVoIPPushToken(userID: userID, authToken: authToken, pushToken: pushToken)
             } catch {
+                CharalarmLogger.error("failed to register VoIP push token, file: \(#file), line: \(#line)", error: error)
             }
         }
     }
@@ -127,9 +128,13 @@ import Foundation
 
         alarms[index].enable = isEnable
         let alarm = alarms[index]
+        guard let userUUID = UUID(uuidString: userID) else {
+            alertMessage = String(localized: "error-failed-to-get-authentication-information")
+            return
+        }
         Task { @MainActor in
             do {
-                let requestBody = AlarmEditRequest(alarm: alarm.toAlarmRequest(userID: UUID(uuidString: userID)!))
+                let requestBody = AlarmEditRequest(alarm: alarm.toAlarmRequest(userID: userUUID))
                 try await apiRepository.editAlarm(userID: userID, authToken: authToken, requestBody: requestBody)
             } catch {
                 alertMessage = String(localized: "alarm-failed-to-edit-the-alarm")

--- a/ios/Charalarm/View/CallView/CallViewState.swift
+++ b/ios/Charalarm/View/CallView/CallViewState.swift
@@ -23,7 +23,7 @@ import AVFoundation
         incomingAudioPlayer?.setVolume(0, fadeDuration: 1)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
             let urlString = self.resourceHandler.getSelfIntroductionUrlString(charaID: self.charaDomain)
-            let url = URL(string: urlString)!
+            guard let url = URL(string: urlString) else { return }
             let playerItem = AVPlayerItem(url: url)
             self.voiceAudioPlayer = AVPlayer(playerItem: playerItem)
             self.voiceAudioPlayer?.play()

--- a/ios/Charalarm/View/CallingView/CallingViewState.swift
+++ b/ios/Charalarm/View/CallingView/CallingViewState.swift
@@ -18,7 +18,8 @@ import AVFoundation
 
     func endCall() {
         guard let callUUID = callUUID else {
-            fatalError("Message")
+            CharalarmLogger.error("endCall failed: callUUID is nil", error: nil)
+            return
         }
 
         let endCallAction = CXEndCallAction(call: callUUID)

--- a/ios/Charalarm/View/Config/ConfigViewState.swift
+++ b/ios/Charalarm/View/Config/ConfigViewState.swift
@@ -26,10 +26,7 @@ import SwiftUI
     }
 
     var charaDomain: String {
-        guard let characterDomain = userDefaultsRepository.getCharaID() else {
-            fatalError("CHARA_DOMAIN が取得できませんでした")
-        }
-        return characterDomain
+        return userDefaultsRepository.getCharaID() ?? ""
     }
 
     func subscriptionButtonTapped() {
@@ -43,7 +40,7 @@ import SwiftUI
     func withdraw() {
         guard let userID = keychainRepository.getUserID(),
               let authToken = keychainRepository.getAuthToken() else {
-            self.alertMessage = "不明なエラーです（UserDefaultsに匿名ユーザー名とかがない）"
+            self.alertMessage = String(localized: "error-failed-to-get-authentication-information")
             self.showingAlert = true
             return
         }

--- a/ios/Charalarm/View/Top/TopViewState.swift
+++ b/ios/Charalarm/View/Top/TopViewState.swift
@@ -191,7 +191,13 @@ enum TopViewModelSheet: Identifiable {
 
         do {
             let data = try fileHandler.loadData(directoryName: charaDomain, fileName: imageName)
-            charaImage = UIImage(data: data)!
+            guard let image = UIImage(data: data) else {
+                DispatchQueue.main.async {
+                    self.alert = .failedToSetCharacterImage
+                }
+                return
+            }
+            charaImage = image
         } catch {
             DispatchQueue.main.async {
                 self.alert = .failedToSetCharacterImage


### PR DESCRIPTION
## Summary
- `UUID(uuidString:)!` や `URL(string:)!` 等の force-unwrap を `guard let` に変更し、クラッシュリスクを除去
- `fatalError()` を安全なフォールバック（ログ出力 + return / 空文字）に置き換え
- `"xyz"`, `"Error"`, `"不明なエラーです（...）"` 等の不適切なエラーメッセージをローカライズ済みメッセージに変更
- `alarmTimeString` の GMT+9 ハードコードを `alarm.timeDifference` 参照に修正
- VoIP push トークン登録失敗の空 `catch {}` にログ出力を追加

## Related Issues
Closes #181, Closes #182, Closes #183, Closes #192, Closes #195

## Test plan
- [ ] アラームの作成・編集・削除が正常に動作すること
- [ ] Keychain に不正な値がある場合にクラッシュせずエラーアラートが表示されること
- [ ] アラーム詳細画面でタイムゾーンが正しく表示されること
- [ ] 通話終了ボタン押下時にクラッシュしないこと
- [ ] 設定画面の退会フローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)