### PR TITLE
Worker: JSONデコード失敗後の処理続行を修正

### DIFF
--- a/application/worker/main.go
+++ b/application/worker/main.go
@@ -35,8 +35,8 @@ func Handler(ctx context.Context, event events.SQSEvent) (events.APIGatewayProxy
 				fmt.Println("@@@@@@@@@@@")
 				fmt.Println("Failed to Send Dead Letter Error")
 				fmt.Println("@@@@@@@@@@@")
-				continue
 			}
+			continue
 		}
 
 		fmt.Println("@@@@@@@@@@@")


### PR DESCRIPTION
## Summary
- `worker/main.go` で `json.Unmarshal` 失敗時、デッドレターキュー送信が成功すると `continue` されず、空の `req` で `PublishPlatformApplication` が実行されるバグを修正
- `continue` をデッドレター送信の成否に関わらずデコード失敗ブロック全体の末尾に移動

Closes #176

## Test plan
- [ ] `go build ./worker/...` ビルド確認済み
- [ ] `go test ./worker/...` テスト確認済み
- [ ] デコード失敗時にデッドレターキュー送信後、次のメッセージに正しくスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)