### PR TITLE
batchDeleteAlarm で DynamoDB client エラーチェックを追加

### DIFF
--- a/application/infrastructure/aws_dynamodb_alarm.go
+++ b/application/infrastructure/aws_dynamodb_alarm.go
@@ -315,6 +315,9 @@ func (a *AWS) deleteAlarm(alarmID string) error {
 
 func (a *AWS) batchDeleteAlarm(ctx context.Context, alarmIDs []string) error {
 	client, err := a.createDynamoDBClient()
+	if err != nil {
+		return err
+	}
 
 	// 一括削除のためのrequestItemsを作成
 	requestItems := make([]types.WriteRequest, 0)


### PR DESCRIPTION
## Summary
- `batchDeleteAlarm` で `createDynamoDBClient()` の戻り値 `err` が未チェックだった問題を修正
- client 作成失敗時に nil client で `BatchWriteItem` を呼んで panic するのを防止

Closes #177

## Test plan
- [ ] `go build ./infrastructure/...` ビルド確認済み
- [ ] `go vet ./infrastructure/...` 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)