### PR TITLE
DynamoDB expression.Build() のエラーチェックを追加

### DIFF
--- a/application/infrastructure/aws_dynamodb_alarm.go
+++ b/application/infrastructure/aws_dynamodb_alarm.go
@@ -52,6 +52,9 @@ func (a *AWS) GetAlarmList(userID string) ([]database.Alarm, error) {
 	// クエリ実行
 	keyEx := expression.Key(database.AlarmTableColumnUserID).Equal(expression.Value(userID))
 	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
+	if err != nil {
+		return []database.Alarm{}, err
+	}
 	output, err := client.Query(context.TODO(), &dynamodb.QueryInput{
 		TableName:                 aws.String(database.AlarmTableName),
 		IndexName:                 aws.String(database.AlarmTableIndexUserID),
@@ -89,6 +92,9 @@ func (a *AWS) QueryByAlarmTime(hour int, minute int, weekday time.Weekday) ([]da
 
 	keyEx := expression.Key(database.AlarmTableColumnTime).Equal(expression.Value(alarmTime))
 	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
+	if err != nil {
+		return []database.Alarm{}, err
+	}
 
 	output, err := client.Query(context.TODO(), &dynamodb.QueryInput{
 		TableName:                 aws.String(database.AlarmTableName),


### PR DESCRIPTION
## Summary
- `GetAlarmList` と `QueryByAlarmTime` で `expression.NewBuilder().Build()` のエラーが未チェックだった問題を修正
- `err` が直後の `client.Query` で上書きされ、expression 構築失敗が検知されなかった

Closes #178

## Test plan
- [ ] `go build ./infrastructure/...` ビルド確認済み
- [ ] `go vet ./infrastructure/...` 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)