### PR TITLE
認証トークンのログ平文出力を削除

### DIFF
--- a/application/api/handler/auth/auth.go
+++ b/application/api/handler/auth/auth.go
@@ -3,13 +3,11 @@ package auth
 import (
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"github.com/takoikatakotako/charalarm/infrastructure/database"
 	"strings"
 )
 
 func Basic(authorizationHeader string) (string, string, error) {
-	fmt.Printf("authHeader: %s\n", authorizationHeader)
 	array := strings.Split(authorizationHeader, " ")
 	if len(array) != 2 {
 		return "", "", errors.New("auth error1")

--- a/application/api/service/alarm.go
+++ b/application/api/service/alarm.go
@@ -174,7 +174,7 @@ func (a *Alarm) GetAlarms(userID string, authToken string) (output.GetAlarms, er
 	} else {
 		pc, fileName, _, _ := runtime.Caller(1)
 		funcName := runtime.FuncForPC(pc).Name()
-		msg := fmt.Sprintf("Authentication Failure, UserID: %s, AuthToken: %s", user.UserID, user.AuthToken)
+		msg := fmt.Sprintf("Authentication Failure, UserID: %s", user.UserID)
 		slog.Error(msg, slog.String("file", fileName), slog.String("func", funcName))
 		return output.GetAlarms{}, errors.New(common.ErrorAuthenticationFailure)
 	}


### PR DESCRIPTION
## Summary
- `auth.go`: Authorization ヘッダーを毎リクエスト stdout に出力するデバッグログを削除
- `alarm.go`: 認証失敗ログから AuthToken を除外し、UserID のみ記録するよう変更

Lambda stdout は CloudWatch Logs に永続化されるため、トークンの平文出力はセキュリティリスク。

Closes #179

## Test plan
- [ ] `go build ./api/...` ビルド確認済み
- [ ] `go vet ./api/...` 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)