### PR TITLE
BatchWriteItem を25件ずつチャンク分割して退会処理の失敗を防止

### DIFF
--- a/application/infrastructure/aws_dynamodb_alarm.go
+++ b/application/infrastructure/aws_dynamodb_alarm.go
@@ -340,14 +340,23 @@ func (a *AWS) batchDeleteAlarm(ctx context.Context, alarmIDs []string) error {
 		requestItems = append(requestItems, requestItem)
 	}
 
-	// アラームを削除
-	_, err = client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
-		RequestItems: map[string][]types.WriteRequest{
-			database.AlarmTableName: requestItems,
-		},
-	})
-	if err != nil {
-		return err
+	// BatchWriteItem は1回最大25件のため、チャンク分割して実行
+	const maxBatchSize = 25
+	for i := 0; i < len(requestItems); i += maxBatchSize {
+		end := i + maxBatchSize
+		if end > len(requestItems) {
+			end = len(requestItems)
+		}
+		chunk := requestItems[i:end]
+
+		_, err = client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+			RequestItems: map[string][]types.WriteRequest{
+				database.AlarmTableName: chunk,
+			},
+		})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `batchDeleteAlarm` で DynamoDB `BatchWriteItem` の上限25件を超えると `ValidationException` が発生する問題を修正
- requestItems を25件ずつチャンク分割してループで `BatchWriteItem` を実行するよう変更

Closes #180

## Test plan
- [ ] `go build ./infrastructure/...` ビルド確認済み
- [ ] `go vet ./infrastructure/...` 確認済み
- [ ] 25件以下のアラーム削除が従来通り動作すること
- [ ] 26件以上のアラームがある場合に退会処理が正常完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)