### PR TITLE
AddAlarm/EditAlarm で nil error による panic を修正

### DIFF
--- a/application/api/service/alarm.go
+++ b/application/api/service/alarm.go
@@ -79,7 +79,7 @@ func (a *Alarm) AddAlarm(input input.AddAlarm) error {
 		// 不明なターゲット
 		pc, fileName, _, _ := runtime.Caller(1)
 		funcName := runtime.FuncForPC(pc).Name()
-		slog.Error(err.Error(), slog.String("file", fileName), slog.String("func", funcName))
+		slog.Error("Unknown alarm type", slog.String("alarmType", input.Alarm.Type), slog.String("file", fileName), slog.String("func", funcName))
 		return errors.New(common.ErrorInvalidValue)
 	}
 	databaseAlarm := convertToDatabaseAlarm(input.Alarm, target)
@@ -112,7 +112,7 @@ func (a *Alarm) EditAlarm(input input.EditAlarm) error {
 		// 不明なターゲット
 		pc, fileName, _, _ := runtime.Caller(1)
 		funcName := runtime.FuncForPC(pc).Name()
-		slog.Error(err.Error(), slog.String("file", fileName), slog.String("func", funcName))
+		slog.Error("Unknown alarm type", slog.String("alarmType", input.Alarm.Type), slog.String("file", fileName), slog.String("func", funcName))
 		return errors.New(common.ErrorInvalidValue)
 	}
 


### PR DESCRIPTION
## Summary
- `AddAlarm` と `EditAlarm` で未知のアラームタイプが来た場合、`err` が nil の状態で `err.Error()` を呼んでいたため panic が発生する問題を修正
- `err.Error()` を具体的なエラーメッセージ文字列 `"Unknown alarm type"` に置き換え、アラームタイプもログに含めるよう改善

Closes #175

## Test plan
- [ ] `go build ./api/...` ビルド確認済み
- [ ] `go vet ./api/...` 確認済み
- [ ] 不正なアラームタイプでリクエストしても panic しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)