### PR TITLE
Lambda のデフォルト値を localhost から空文字に変更

### DIFF
--- a/application/api/main.go
+++ b/application/api/main.go
@@ -12,8 +12,8 @@ import (
 func main() {
 	// environment
 	env := environment.Environment{}
-	env.SetCharalarmAWSProfile("")
-	env.SetResourceBaseURL("")
+	env.SetCharalarmAWSProfile("local")
+	env.SetResourceBaseURL("http://localhost:4566")
 
 	// infrastructure
 	awsRepository := infrastructure.AWS{

--- a/application/api/main.go
+++ b/application/api/main.go
@@ -12,8 +12,8 @@ import (
 func main() {
 	// environment
 	env := environment.Environment{}
-	env.SetCharalarmAWSProfile("local")
-	env.SetResourceBaseURL("http://localhost:4566")
+	env.SetCharalarmAWSProfile("")
+	env.SetResourceBaseURL("")
 
 	// infrastructure
 	awsRepository := infrastructure.AWS{

--- a/application/batch/main.go
+++ b/application/batch/main.go
@@ -8,24 +8,14 @@ import (
 	"github.com/takoikatakotako/charalarm/batch/service"
 	"github.com/takoikatakotako/charalarm/environment"
 	"github.com/takoikatakotako/charalarm/infrastructure"
-	"os"
 	"time"
 )
-
-func getEnvironment(key string, defaultValue string) string {
-	// 環境変数の値を取得
-	val, exists := os.LookupEnv(key)
-	if !exists {
-		return defaultValue
-	}
-	return val
-}
 
 func handler(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// environment
 	env := environment.Environment{}
-	env.SetResourceBaseURL("local")
-	env.SetResourceBaseURL("http://localhost:4566")
+	env.SetCharalarmAWSProfile("")
+	env.SetResourceBaseURL("")
 
 	// Repository
 	awsRepository := infrastructure.AWS{

--- a/application/infrastructure/aws_sqs.go
+++ b/application/infrastructure/aws_sqs.go
@@ -83,7 +83,10 @@ func (a *AWS) ReceiveAlarmInfoMessage() ([]types.Message, error) {
 }
 
 func (a *AWS) PurgeQueue() error {
-	queueURL := "http://localhost:4566/000000000000/voip-push-queue.fifo"
+	queueURL, err := a.GetQueueURL(VoIPPushQueueName)
+	if err != nil {
+		return err
+	}
 
 	// SQSClient作成
 	client, err := a.createSQSClient()


### PR DESCRIPTION
## Summary
- `api/main.go`: デフォルト値 `"local"` / `"http://localhost:4566"` を空文字に変更（環境変数で設定する前提）
- `batch/main.go`: L27 の dead assignment（`SetResourceBaseURL("local")` → 直後に上書き）を `SetCharalarmAWSProfile("")` に修正、未使用の `getEnvironment` 関数を削除
- `aws_sqs.go`: `PurgeQueue` のハードコード URL を `GetQueueURL()` で動的取得に変更

Closes #191

## Test plan
- [ ] `go build` / `go vet` 確認済み
- [ ] 環境変数 `CHARALARM_AWS_PROFILE` / `CHARALARM_RESOURCE_BASE_URL` が設定されている環境で正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)