### PR TITLE
development / staging の CloudWatch Dashboard を無効化（コスト削減）

### DIFF
--- a/terraform/environment/development/monitoring.tf
+++ b/terraform/environment/development/monitoring.tf
@@ -6,6 +6,9 @@ module "monitoring" {
   name_prefix                      = local.prefix
   slack_webhook_ssm_parameter_name = "/charalarm/dev/slack-webhook-url"
 
+  # コスト削減のため Dashboard は作成しない (Alarm / Slack 通知は維持)
+  create_dashboard = false
+
   worker_function_name = module.worker.function_name
   batch_function_name  = module.batch.function_name
 

--- a/terraform/environment/staging/monitoring.tf
+++ b/terraform/environment/staging/monitoring.tf
@@ -6,6 +6,9 @@ module "monitoring" {
   name_prefix                      = local.prefix
   slack_webhook_ssm_parameter_name = "/charalarm/staging/slack-webhook-url"
 
+  # コスト削減のため Dashboard は作成しない (Alarm / Slack 通知は維持)
+  create_dashboard = false
+
   worker_function_name = module.worker2.function_name
   batch_function_name  = module.batch2.function_name
 

--- a/terraform/modules/monitoring/dashboard.tf
+++ b/terraform/modules/monitoring/dashboard.tf
@@ -138,6 +138,7 @@ locals {
 }
 
 resource "aws_cloudwatch_dashboard" "main" {
+  count          = var.create_dashboard ? 1 : 0
   dashboard_name = var.name_prefix
   dashboard_body = local.dashboard_body
 }

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -3,7 +3,7 @@ output "sns_topic_arn" {
 }
 
 output "dashboard_name" {
-  value = aws_cloudwatch_dashboard.main.dashboard_name
+  value = var.create_dashboard ? aws_cloudwatch_dashboard.main[0].dashboard_name : null
 }
 
 output "slack_notifier_function_name" {

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -39,3 +39,9 @@ variable "api_cloudfront_distribution_ids" {
   description = "Dashboard に表示する CloudFront distribution ID のマップ (ラベル → ID)"
   default     = {}
 }
+
+variable "create_dashboard" {
+  type        = bool
+  description = "CloudWatch Dashboard を作成するか (コスト削減のため development/staging では false)"
+  default     = true
+}


### PR DESCRIPTION
## 概要

CloudWatch Dashboard のコストが嵩んでいるため、development / staging のダッシュボードを削除します。

## 変更内容

`monitoring` モジュールに `create_dashboard` フラグ（bool, デフォルト `true`）を追加し、Dashboard リソースを `count` で制御できるようにしました。

- `terraform/modules/monitoring/variables.tf`: `create_dashboard` 変数を追加
- `terraform/modules/monitoring/dashboard.tf`: `aws_cloudwatch_dashboard.main` に `count = var.create_dashboard ? 1 : 0`
- `terraform/modules/monitoring/outputs.tf`: `dashboard_name` を null セーフに
- `terraform/environment/development/monitoring.tf`: `create_dashboard = false`
- `terraform/environment/staging/monitoring.tf`: `create_dashboard = false`

## 影響範囲

- **Dashboard のみ削除**。CloudWatch Alarm と Slack 通知は維持されます。
- **production は影響なし**（デフォルト `true` のまま）。

## 適用イメージ

\`\`\`
# module.monitoring.aws_cloudwatch_dashboard.main[0] will be destroyed
\`\`\`

## 確認事項

- [x] `terraform fmt` 済み
- [x] development / staging で `terraform validate` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)