### PR TITLE
docs: Production API のヘルスチェックURLを api2 → api3 に修正

### DIFF
--- a/docs/development/api-endpoint.md
+++ b/docs/development/api-endpoint.md
@@ -15,7 +15,7 @@ API: [https://api.charalarm.swiswiswift.com/healthcheck](https://api.charalarm.s
 # Production
 オリジン: [https://charalarm.com](https://charalarm.com)
 リソース: [https://resource.charalarm.com/com.charalarm.yui/thumbnail.png](https://resource.charalarm.com/com.charalarm.yui/thumbnail.png)
-API: [https://api2.charalarm.com/healthcheck](https://api2.charalarm.com/healthcheck)
+API: [https://api3.charalarm.com/healthcheck](https://api3.charalarm.com/healthcheck)
 
 
 # /


### PR DESCRIPTION
## 概要

`docs/development/api-endpoint.md` の Production API ヘルスチェックURLが、撤去済みの旧ドメイン `api2.charalarm.com` を指したままだったため、現本番の `api3.charalarm.com` に更新する。

旧ドメイン `api.charalarm.com` / `api2.charalarm.com` は Issue #214 / PR #216 で完全撤去済み(カスタムドメイン + Route53 レコード削除、現在は DNS 解決不能)。

## 変更

```diff
- API: https://api2.charalarm.com/healthcheck
+ API: https://api3.charalarm.com/healthcheck
```

## #218 の残作業(本PR対象外)

外形監視は **リポジトリ外の外部サービス** で管理されており、`api.charalarm.com` / `api2.charalarm.com` の監視対象削除・`api3.charalarm.com` への切り替えは、そのサービスのダッシュボードでの手動作業が必要。本リポジトリのコード・Terraform 内には URL ベースの外形監視定義は存在しないことを確認済み(monitoring モジュールは CloudWatch アラームのみ)。

→ 外部サービス側の対応完了後に Issue #218 をクローズしてください。

Refs #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)