### PR TITLE
S3 バケットのパブリックアクセスを遮断し CloudFront OAC 経由に限定

### DIFF
--- a/terraform/modules/lp/main.tf
+++ b/terraform/modules/lp/main.tf
@@ -5,6 +5,14 @@ resource "aws_s3_bucket" "s3_bucket" {
   bucket = var.bucket_name
 }
 
+resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
+  bucket                  = aws_s3_bucket.s3_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_policy" "s3_bucket_policy" {
   bucket = aws_s3_bucket.s3_bucket.id
   policy = data.aws_iam_policy_document.iam_policy_document.json
@@ -14,58 +22,44 @@ resource "aws_s3_bucket_policy" "s3_bucket_policy" {
   ]
 }
 
-resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
-  bucket                  = aws_s3_bucket.s3_bucket.id
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
-}
-
+# CloudFront (OAC) からの GetObject のみ許可
 data "aws_iam_policy_document" "iam_policy_document" {
   statement {
-    sid = "AddPerm"
+    sid    = "AllowCloudFrontServicePrincipalReadOnly"
+    effect = "Allow"
     actions = [
       "s3:GetObject"
     ]
     principals {
-      type        = "*"
-      identifiers = ["*"]
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
     }
     resources = [
-      "arn:aws:s3:::${var.bucket_name}/*"
+      "${aws_s3_bucket.s3_bucket.arn}/*"
     ]
-  }
-}
-
-resource "aws_s3_bucket_website_configuration" "bucket_website_configuration" {
-  bucket = aws_s3_bucket.s3_bucket.id
-
-  index_document {
-    suffix = "index.html"
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.charalarm_cloudfront_distribution.arn]
+    }
   }
 }
 
 ##############################################################
 # CloudFront
 ##############################################################
+resource "aws_cloudfront_origin_access_control" "s3_oac" {
+  name                              = var.bucket_name
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
 resource "aws_cloudfront_distribution" "charalarm_cloudfront_distribution" {
   origin {
-    domain_name = "${var.bucket_name}.s3-website-ap-northeast-1.amazonaws.com"
-    origin_id   = "S3-${var.bucket_name}"
-
-    custom_origin_config {
-      http_port                = 80
-      https_port               = 443
-      origin_keepalive_timeout = 5
-      origin_protocol_policy   = "http-only"
-      origin_read_timeout      = 30
-      origin_ssl_protocols = [
-        "TLSv1",
-        "TLSv1.1",
-        "TLSv1.2",
-      ]
-    }
+    domain_name              = aws_s3_bucket.s3_bucket.bucket_regional_domain_name
+    origin_id                = "S3-${var.bucket_name}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.s3_oac.id
   }
 
   aliases = [

--- a/terraform/modules/resource/main.tf
+++ b/terraform/modules/resource/main.tf
@@ -5,6 +5,14 @@ resource "aws_s3_bucket" "s3_bucket" {
   bucket = var.bucket_name
 }
 
+resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
+  bucket                  = aws_s3_bucket.s3_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_policy" "s3_bucket_policy" {
   bucket = aws_s3_bucket.s3_bucket.id
   policy = data.aws_iam_policy_document.iam_policy_document.json
@@ -14,27 +22,26 @@ resource "aws_s3_bucket_policy" "s3_bucket_policy" {
   ]
 }
 
-resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
-  bucket                  = aws_s3_bucket.s3_bucket.id
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
-}
-
+# CloudFront (OAC) からの GetObject のみ許可
 data "aws_iam_policy_document" "iam_policy_document" {
   statement {
-    sid = "AddPerm"
+    sid    = "AllowCloudFrontServicePrincipalReadOnly"
+    effect = "Allow"
     actions = [
       "s3:GetObject"
     ]
     principals {
-      type        = "*"
-      identifiers = ["*"]
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
     }
     resources = [
-      "arn:aws:s3:::${var.bucket_name}/*"
+      "${aws_s3_bucket.s3_bucket.arn}/*"
     ]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.charalarm_cloudfront_distribution.arn]
+    }
   }
 }
 
@@ -42,10 +49,18 @@ data "aws_iam_policy_document" "iam_policy_document" {
 ##############################################################
 # CloudFront
 ##############################################################
+resource "aws_cloudfront_origin_access_control" "s3_oac" {
+  name                              = var.bucket_name
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
 resource "aws_cloudfront_distribution" "charalarm_cloudfront_distribution" {
   origin {
-    domain_name = "${var.bucket_name}.s3.amazonaws.com"
-    origin_id   = "S3-${var.bucket_name}"
+    domain_name              = aws_s3_bucket.s3_bucket.bucket_regional_domain_name
+    origin_id                = "S3-${var.bucket_name}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.s3_oac.id
   }
 
   aliases = [


### PR DESCRIPTION
## 概要

`resource` / `lp` の S3 バケットがパブリックアクセスブロック全 `false` + バケットポリシー `Principal "*"` で**直接公開**されていた(Issue #197)。CloudFront OAC 経由のアクセスのみ許可するよう、既存の `admin_frontend` モジュールと同じ方式に統一する。

## 変更内容(両モジュール共通)

| 項目 | Before | After |
|---|---|---|
| public access block | 全 `false`(全開放) | 全 `true`(全遮断) |
| バケットポリシー | `Principal: "*"` で誰でも `GetObject` | `cloudfront.amazonaws.com` + `AWS:SourceArn` 条件(該当 Distribution のみ) |
| CloudFront → S3 | 素の S3 ドメイン直参照 | `aws_cloudfront_origin_access_control`(s3 / sigv4)+ `bucket_regional_domain_name` |

## `lp` 固有の変更(アーキテクチャ移行)

S3 **ウェブサイトホスティング**(website endpoint)は OAC 非対応のため、**REST オリジン + OAC** へ移行:
- `aws_s3_bucket_website_configuration` を削除
- オリジンを website endpoint(`http-only` custom_origin_config)→ `bucket_regional_domain_name` + OAC に変更
- LP は単一ページ構成(`index.html` / `app-ads.txt` / `css/` / `js/`、サブディレクトリ index 無し)のため、`default_root_object = index.html` でルート `/` を解決。`app-ads.txt` 等は直パスで配信され、ディレクトリインデックス機能には依存していないことを確認済み

## 影響範囲

- `resource`: development / staging / production の3環境
- `lp`: production のみ

## 確認

- `terraform validate`(environment/production、両モジュールを使用)パス
- `terraform fmt` パス

## ⚠️ apply 時の注意(レビュー後・手動)

本PRはコード変更のみ。apply は **dev → staging → production の順**で慎重に:

1. **`resource`**: apply 後、S3 直 URL(`*.s3.amazonaws.com/...`)は 403 になる。配信は `resource.<domain>`(CloudFront)経由のみになるため、**iOS アプリ等が S3 直アクセスしていないこと**を事前確認(CLAUDE.md 上は CloudFront 配信前提)。
2. **`lp`**: CloudFront オリジン差し替え + website 設定削除のため反映に数分。apply 後 `https://charalarm.com/`・`/app-ads.txt`・CSS/JS が 200 で返ることを確認(`app-ads.txt` は AdMob 用なので要確認)。
3. CloudFront のオリジン変更は In-Place 更新(Distribution は再作成されない)。

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)