### PR TITLE
お知らせ配信機能（管理画面から即時配信 → アプリ内お知らせ一覧）

### DIFF
--- a/admin/src/app/news/page.tsx
+++ b/admin/src/app/news/page.tsx
@@ -1,0 +1,5 @@
+import { NewsPage } from "@/components/news/news-page";
+
+export default function Page() {
+  return <NewsPage />;
+}

--- a/admin/src/components/layout/sidebar.tsx
+++ b/admin/src/components/layout/sidebar.tsx
@@ -2,11 +2,12 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Users } from "lucide-react";
+import { Users, Megaphone } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const navigation = [
   { name: "ユーザー", href: "/users", icon: Users },
+  { name: "お知らせ", href: "/news", icon: Megaphone },
 ];
 
 export function Sidebar() {

--- a/admin/src/components/news/news-page.tsx
+++ b/admin/src/components/news/news-page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { useNews } from "@/hooks/use-news";
+import { createNews, deleteNews } from "@/lib/api/news";
+import { ApiClientError } from "@/lib/api/client";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Trash2 } from "lucide-react";
+
+const inputClass =
+  "w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString("ja-JP");
+}
+
+export function NewsPage() {
+  const { data, error, isLoading, mutate } = useNews();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const canSubmit = title.trim() !== "" && body.trim() !== "" && !submitting;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      await createNews(title.trim(), body.trim());
+      toast.success("お知らせを配信しました");
+      setTitle("");
+      setBody("");
+      await mutate();
+    } catch (err) {
+      const message =
+        err instanceof ApiClientError ? err.message : "配信に失敗しました";
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (newsId: string) => {
+    if (!window.confirm("このお知らせを削除しますか？")) return;
+    setDeletingId(newsId);
+    try {
+      await deleteNews(newsId);
+      toast.success("お知らせを削除しました");
+      await mutate();
+    } catch (err) {
+      const message =
+        err instanceof ApiClientError ? err.message : "削除に失敗しました";
+      toast.error(message);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const newsList = data?.news ?? [];
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <h1 className="text-2xl font-bold">お知らせ配信</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>新規配信</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+              <label htmlFor="news-title" className="text-sm font-medium">
+                タイトル
+              </label>
+              <input
+                id="news-title"
+                className={inputClass}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="例: v4.1 をリリースしました"
+                maxLength={100}
+                disabled={submitting}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label htmlFor="news-body" className="text-sm font-medium">
+                本文
+              </label>
+              <textarea
+                id="news-body"
+                className={`${inputClass} min-h-32 resize-y`}
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                placeholder="お知らせの本文を入力してください"
+                disabled={submitting}
+              />
+            </div>
+            <div className="flex justify-end">
+              <Button type="submit" disabled={!canSubmit}>
+                {submitting ? "配信中..." : "配信する"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">配信済み</h2>
+
+        {isLoading && <p className="text-muted-foreground">読み込み中...</p>}
+        {error && <p className="text-destructive">エラーが発生しました</p>}
+
+        {data && newsList.length === 0 && (
+          <p className="text-muted-foreground">お知らせはまだありません</p>
+        )}
+
+        {newsList.map((news) => (
+          <Card key={news.newsId}>
+            <CardContent className="flex items-start justify-between gap-4 py-4">
+              <div className="min-w-0 space-y-1">
+                <p className="font-medium">{news.title}</p>
+                <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
+                  {news.body}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {formatDate(news.registeredAt)}
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleDelete(news.newsId)}
+                disabled={deletingId === news.newsId}
+                aria-label="削除"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/admin/src/hooks/use-news.ts
+++ b/admin/src/hooks/use-news.ts
@@ -1,0 +1,7 @@
+import useSWR from "swr";
+import { fetchNews } from "@/lib/api/news";
+import type { NewsListResponse } from "@/lib/api/types";
+
+export function useNews() {
+  return useSWR<NewsListResponse>("/news", fetchNews);
+}

--- a/admin/src/lib/api/client.ts
+++ b/admin/src/lib/api/client.ts
@@ -29,3 +29,17 @@ export async function apiGet<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);
   return handleResponse<T>(response);
 }
+
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<T>(response);
+}
+
+export async function apiDelete<T = void>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, { method: "DELETE" });
+  return handleResponse<T>(response);
+}

--- a/admin/src/lib/api/news.ts
+++ b/admin/src/lib/api/news.ts
@@ -1,0 +1,14 @@
+import { apiGet, apiPost, apiDelete } from "@/lib/api/client";
+import type { News, NewsListResponse } from "@/lib/api/types";
+
+export async function fetchNews(): Promise<NewsListResponse> {
+  return apiGet<NewsListResponse>("/news");
+}
+
+export async function createNews(title: string, body: string): Promise<News> {
+  return apiPost<News>("/news", { title, body });
+}
+
+export async function deleteNews(newsId: string): Promise<void> {
+  return apiDelete(`/news/${encodeURIComponent(newsId)}`);
+}

--- a/admin/src/lib/api/types.ts
+++ b/admin/src/lib/api/types.ts
@@ -45,3 +45,14 @@ export interface Alarm {
 export interface UserAlarmsResponse {
   alarms: Alarm[];
 }
+
+export interface News {
+  newsId: string;
+  title: string;
+  body: string;
+  registeredAt: string;
+}
+
+export interface NewsListResponse {
+  news: News[];
+}

--- a/application/admin_api/handler/news.go
+++ b/application/admin_api/handler/news.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takoikatakotako/charalarm/admin_api/service"
+	"github.com/takoikatakotako/charalarm/admin_api/service/output"
+)
+
+type News struct {
+	Service service.News
+}
+
+type newsResponse struct {
+	NewsID       string `json:"newsId"`
+	Title        string `json:"title"`
+	Body         string `json:"body"`
+	RegisteredAt string `json:"registeredAt"`
+}
+
+type newsListResponse struct {
+	News []newsResponse `json:"news"`
+}
+
+type newsCreateRequest struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+func (n *News) NewsListGet(c echo.Context) error {
+	newsList, err := n.Service.ScanNews()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, newErrorResponse("scan_news_failed", err.Error()))
+	}
+
+	res := make([]newsResponse, 0, len(newsList))
+	for _, item := range newsList {
+		res = append(res, toNewsResponse(item))
+	}
+	return c.JSON(http.StatusOK, newsListResponse{News: res})
+}
+
+func (n *News) NewsPost(c echo.Context) error {
+	req := new(newsCreateRequest)
+	if err := c.Bind(req); err != nil {
+		return c.JSON(http.StatusBadRequest, newErrorResponse("invalid_request", err.Error()))
+	}
+
+	title := strings.TrimSpace(req.Title)
+	body := strings.TrimSpace(req.Body)
+	if title == "" || body == "" {
+		return c.JSON(http.StatusBadRequest, newErrorResponse("invalid_request", "title and body are required"))
+	}
+
+	created, err := n.Service.CreateNews(title, body)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, newErrorResponse("create_news_failed", err.Error()))
+	}
+	return c.JSON(http.StatusOK, toNewsResponse(created))
+}
+
+func (n *News) NewsDelete(c echo.Context) error {
+	newsID := c.Param("newsID")
+	if newsID == "" {
+		return c.JSON(http.StatusBadRequest, newErrorResponse("invalid_news_id", "newsID is required"))
+	}
+
+	if err := n.Service.DeleteNews(newsID); err != nil {
+		return c.JSON(http.StatusInternalServerError, newErrorResponse("delete_news_failed", err.Error()))
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func toNewsResponse(n output.News) newsResponse {
+	return newsResponse{
+		NewsID:       n.NewsID,
+		Title:        n.Title,
+		Body:         n.Body,
+		RegisteredAt: n.RegisteredAt,
+	}
+}

--- a/application/admin_api/main.go
+++ b/application/admin_api/main.go
@@ -23,6 +23,9 @@ func main() {
 	alarmService := service.Alarm{
 		AWS: awsRepository,
 	}
+	newsService := service.News{
+		AWS: awsRepository,
+	}
 
 	healthcheckHandler := handler.Healthcheck{}
 	userHandler := handler.User{
@@ -30,6 +33,9 @@ func main() {
 	}
 	alarmHandler := handler.Alarm{
 		Service: alarmService,
+	}
+	newsHandler := handler.News{
+		Service: newsService,
 	}
 
 	e := echo.New()
@@ -41,6 +47,10 @@ func main() {
 	e.GET("/users", userHandler.UsersGet)
 	e.GET("/users/:userID", userHandler.UserGet)
 	e.GET("/users/:userID/alarms", alarmHandler.UserAlarmsGet)
+
+	e.GET("/news", newsHandler.NewsListGet)
+	e.POST("/news", newsHandler.NewsPost)
+	e.DELETE("/news/:newsID", newsHandler.NewsDelete)
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/application/admin_api/service/news.go
+++ b/application/admin_api/service/news.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/takoikatakotako/charalarm/admin_api/service/output"
+	"github.com/takoikatakotako/charalarm/infrastructure"
+	"github.com/takoikatakotako/charalarm/infrastructure/database"
+)
+
+type News struct {
+	AWS infrastructure.AWS
+}
+
+// ScanNews お知らせを新しい順で返す。
+func (s *News) ScanNews() ([]output.News, error) {
+	newsList, err := s.AWS.ScanNews()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]output.News, 0, len(newsList))
+	for _, n := range newsList {
+		out = append(out, toNewsOutput(n))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].RegisteredAt > out[j].RegisteredAt
+	})
+	return out, nil
+}
+
+// CreateNews お知らせを作成して即公開する。
+func (s *News) CreateNews(title string, body string) (output.News, error) {
+	news := database.News{
+		NewsID:       uuid.New().String(),
+		Title:        title,
+		Body:         body,
+		RegisteredAt: time.Now().Format(time.RFC3339),
+	}
+	if err := s.AWS.InsertNews(news); err != nil {
+		return output.News{}, err
+	}
+	return toNewsOutput(news), nil
+}
+
+// DeleteNews お知らせを削除する。
+func (s *News) DeleteNews(newsID string) error {
+	return s.AWS.DeleteNews(newsID)
+}
+
+func toNewsOutput(n database.News) output.News {
+	return output.News{
+		NewsID:       n.NewsID,
+		Title:        n.Title,
+		Body:         n.Body,
+		RegisteredAt: n.RegisteredAt,
+	}
+}

--- a/application/admin_api/service/output/news.go
+++ b/application/admin_api/service/output/news.go
@@ -1,0 +1,8 @@
+package output
+
+type News struct {
+	NewsID       string
+	Title        string
+	Body         string
+	RegisteredAt string
+}

--- a/application/api/handler/news.go
+++ b/application/api/handler/news.go
@@ -1,17 +1,31 @@
 package handler
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/takoikatakotako/charalarm/api/handler/response"
-	"net/http"
+	"github.com/takoikatakotako/charalarm/api/service"
 )
 
 type News struct {
+	Service service.News
 }
 
 func (n *News) NewsListGet(c echo.Context) error {
-	res := response.Message{
-		Message: Healthy,
+	newsList, err := n.Service.ListNews()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, response.Message{Message: "Error!"})
+	}
+
+	res := make([]response.News, 0, len(newsList))
+	for _, item := range newsList {
+		res = append(res, response.News{
+			NewsID:       item.NewsID,
+			Title:        item.Title,
+			Body:         item.Body,
+			RegisteredAt: item.RegisteredAt,
+		})
 	}
 	return c.JSON(http.StatusOK, res)
 }

--- a/application/api/handler/response/news.go
+++ b/application/api/handler/response/news.go
@@ -1,0 +1,9 @@
+package response
+
+// News はアプリ向けのお知らせレスポンス。
+type News struct {
+	NewsID       string `json:"newsId"`
+	Title        string `json:"title"`
+	Body         string `json:"body"`
+	RegisteredAt string `json:"registeredAt"`
+}

--- a/application/api/main.go
+++ b/application/api/main.go
@@ -47,6 +47,9 @@ func main() {
 	pushTokenService := service.PushToken{
 		AWS: awsRepository,
 	}
+	newsService := service.News{
+		AWS: awsRepository,
+	}
 	chatService := service.Chat{
 		AWS:       awsRepository,
 		LLMClient: llm.NewClient(env.LLMProvider, env.OpenAIAPIKey, env.LLMModel),
@@ -68,7 +71,9 @@ func main() {
 	pushTokenHandler := handler.PushToken{
 		Service: pushTokenService,
 	}
-	newsHandler := handler.News{}
+	newsHandler := handler.News{
+		Service: newsService,
+	}
 	chatHandler := handler.Chat{
 		Service: chatService,
 	}

--- a/application/api/service/news.go
+++ b/application/api/service/news.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"sort"
+
+	"github.com/takoikatakotako/charalarm/api/service/output"
+	"github.com/takoikatakotako/charalarm/infrastructure"
+)
+
+type News struct {
+	AWS infrastructure.AWS
+}
+
+// ListNews お知らせを新しい順で返す。
+func (s *News) ListNews() ([]output.News, error) {
+	newsList, err := s.AWS.ScanNews()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]output.News, 0, len(newsList))
+	for _, n := range newsList {
+		out = append(out, output.News{
+			NewsID:       n.NewsID,
+			Title:        n.Title,
+			Body:         n.Body,
+			RegisteredAt: n.RegisteredAt,
+		})
+	}
+
+	// registeredAt (RFC3339) は文字列比較で新しい順にソートできる
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].RegisteredAt > out[j].RegisteredAt
+	})
+
+	return out, nil
+}

--- a/application/api/service/output/news.go
+++ b/application/api/service/output/news.go
@@ -1,0 +1,8 @@
+package output
+
+type News struct {
+	NewsID       string
+	Title        string
+	Body         string
+	RegisteredAt string
+}

--- a/application/infrastructure/aws_dynamodb_news.go
+++ b/application/infrastructure/aws_dynamodb_news.go
@@ -1,0 +1,89 @@
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/takoikatakotako/charalarm/infrastructure/database"
+)
+
+// ScanNews お知らせを全件取得する (件数が少ない前提で Scan)
+func (a *AWS) ScanNews() ([]database.News, error) {
+	client, err := a.createDynamoDBClient()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	output, err := client.Scan(ctx, &dynamodb.ScanInput{
+		TableName: aws.String(database.NewsTableName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	newsList := make([]database.News, 0, len(output.Items))
+	for _, item := range output.Items {
+		news := database.News{}
+		if err := attributevalue.UnmarshalMap(item, &news); err != nil {
+			continue
+		}
+		newsList = append(newsList, news)
+	}
+	return newsList, nil
+}
+
+// InsertNews お知らせを追加する
+func (a *AWS) InsertNews(news database.News) error {
+	if err := database.ValidateNews(news); err != nil {
+		return err
+	}
+
+	client, err := a.createDynamoDBClient()
+	if err != nil {
+		return err
+	}
+
+	av, err := attributevalue.MarshalMap(news)
+	if err != nil {
+		fmt.Printf("dynamodb marshal: %s\n", err.Error())
+		return err
+	}
+
+	ctx := context.Background()
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(database.NewsTableName),
+		Item:      av,
+	})
+	if err != nil {
+		fmt.Printf("put item: %s\n", err.Error())
+		return err
+	}
+	return nil
+}
+
+// DeleteNews お知らせを削除する
+func (a *AWS) DeleteNews(newsID string) error {
+	client, err := a.createDynamoDBClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	_, err = client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(database.NewsTableName),
+		Key: map[string]types.AttributeValue{
+			database.NewsTableNewsID: &types.AttributeValueMemberS{
+				Value: newsID,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/application/infrastructure/database/news.go
+++ b/application/infrastructure/database/news.go
@@ -1,0 +1,33 @@
+package database
+
+import (
+	"errors"
+
+	"github.com/takoikatakotako/charalarm/common"
+)
+
+const (
+	NewsTableName   = "news-table"
+	NewsTableNewsID = "newsID"
+)
+
+// News はアプリ内お知らせ (タイトル + 本文)。
+type News struct {
+	NewsID       string `dynamodbav:"newsID"`
+	Title        string `dynamodbav:"title"`
+	Body         string `dynamodbav:"body"`
+	RegisteredAt string `dynamodbav:"registeredAt"` // RFC3339
+}
+
+func ValidateNews(news News) error {
+	if !IsValidUUID(news.NewsID) {
+		return errors.New(common.ErrorInvalidValue + ": NewsID")
+	}
+	if news.Title == "" {
+		return errors.New(common.ErrorInvalidValue + ": Title")
+	}
+	if news.Body == "" {
+		return errors.New(common.ErrorInvalidValue + ": Body")
+	}
+	return nil
+}

--- a/ios/Charalarm/Entity/News.swift
+++ b/ios/Charalarm/Entity/News.swift
@@ -1,22 +1,18 @@
 import Foundation
 
 struct News: Decodable, Identifiable {
-    var id: Int {
+    var id: String {
         return newsId
     }
-    let newsId: Int
-    let siteName: String
-    let url: String
+    let newsId: String
     let title: String
-    let description: String
+    let body: String
     let registeredAt: Date
 
     private enum CodingKeys: String, CodingKey {
         case newsId
-        case siteName
-        case url
         case title
-        case description
+        case body
         case registeredAt
     }
 }

--- a/ios/Charalarm/Repository/APIRepository.swift
+++ b/ios/Charalarm/Repository/APIRepository.swift
@@ -147,6 +147,18 @@ extension APIRepository {
 }
 
 extension APIRepository {
+    /// お知らせ一覧を取得する（新しい順）。
+    func getNewsList() async throws -> [News] {
+        let path = "/news/list"
+        let url = try createURL(path: path)
+        let requestHeader: [String: String] = APIHeader.defaultHeader
+        let requestBody: Encodable? = nil
+        let newsList: [News] = try await APIClient().request(url: url, httpMethod: .get, requestHeader: requestHeader, requestBody: requestBody)
+        return newsList
+    }
+}
+
+extension APIRepository {
     /// ずんだもんとの会話応答を backend `/chat` から取得する。
     func postChat(userID: String, authToken: String, messages: [ChatMessage]) async throws -> String {
         let path = "/chat"

--- a/ios/Charalarm/Repository/NewsRepository.swift
+++ b/ios/Charalarm/Repository/NewsRepository.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct NewsRepository {
+    private let apiRepository = APIRepository()
+
+    func fetchNews() async throws -> [News] {
+        try await apiRepository.getNewsList()
+    }
+}

--- a/ios/Charalarm/View/News/NewsListView.swift
+++ b/ios/Charalarm/View/News/NewsListView.swift
@@ -2,20 +2,12 @@ import SwiftUI
 
 struct NewsListView: View {
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.openURL) private var openURL
     @State private var viewModel = NewsListViewModel()
 
     var body: some View {
         NavigationStack {
             List(viewModel.newsList) { news in
-                Button {
-                    guard let url = URL(string: news.url) else {
-                        return
-                    }
-                    openURL(url)
-                } label: {
-                    NewsRow(news: news)
-                }
+                NewsRow(news: news)
             }
             .navigationTitle(String(localized: "news-news"))
             .navigationBarTitleDisplayMode(.inline)

--- a/ios/Charalarm/View/News/NewsListViewModel.swift
+++ b/ios/Charalarm/View/News/NewsListViewModel.swift
@@ -4,17 +4,17 @@ import SwiftUI
     var newsList: [News] = []
     var showingAlert = false
     var alertMessage = ""
-    // let newsRepository: NewsRepository = NewsRepository()
+    private let newsRepository = NewsRepository()
 
     func fetchNews() {
         Task { @MainActor in
-//            do {
-//                // let news = try await newsRepository.fetchNews()
-//                // self.newsList = news
-//            } catch {
-//                self.alertMessage = String(localized: "news-failed-to-get-the-news")
-//                self.showingAlert = true
-//            }
+            do {
+                let news = try await newsRepository.fetchNews()
+                self.newsList = news
+            } catch {
+                self.alertMessage = String(localized: "news-failed-to-get-the-news")
+                self.showingAlert = true
+            }
         }
     }
 }

--- a/ios/Charalarm/View/News/NewsRow.swift
+++ b/ios/Charalarm/View/News/NewsRow.swift
@@ -11,26 +11,26 @@ struct NewsRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(registerdAtString)
-                    .lineLimit(1)
-                Spacer()
-                Text(news.siteName)
-                    .lineLimit(1)
-            }
+            Text(registerdAtString)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
             Text(news.title)
-                .lineLimit(2)
+                .font(.headline)
+            Text(news.body)
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
         }
+        .padding(.vertical, 4)
     }
 }
 
 private struct NewsRowPreviewWrapper: View {
     let news = News(
-        newsId: 1,
-        siteName: "Twitter",
-        url: "google.com",
-        title: "IntelliJでJavaのGradleのプロジェクトを作成する",
-        description: "IntelliJでJavaのGradleのプロジェクトを作成する方法です。", registeredAt: Date())
+        newsId: "00000000-0000-0000-0000-000000000000",
+        title: "アップデートしました",
+        body: "ずんだもんと音声で会話できるようになったのだ！ぜひ試してみてほしいのだ〜。",
+        registeredAt: Date())
     var body: some View {
         NewsRow(news: news)
     }

--- a/local/createTable.sh
+++ b/local/createTable.sh
@@ -84,4 +84,14 @@ aws dynamodb put-item \
     --item '{"charaID":{"S":"com.senpu-ki-soft.momiji"},"enable":{"BOOL":true},"name":{"S":"紅葉"},"created_at":{"S":"2023-06-05"},"updated_at":{"S":"2023-06-14"},"description":{"S":"金髪紅眼の美少女。疲れ気味のあなたを心配して様々な癒しを、と考えている。その正体は幾百年を生きる鬼の末裔。あるいはあなたに恋慕を抱く彼女。ちょっと素直になりきれないものの、なんやかんやいってそばにいてくれる面倒見のいい少女。日々あなたの生活を見届けている。「わっち？　名は紅葉でありんす。主様の支えになれるよう、掃除でもみみかきでもなんでも言っておくんなんし。か、かわいい？　い、いきなりそんなこと言わないでおくんなんし！」"},"calls":{"L":[{"M":{"message":{"S":"紅葉さんの天気だね。"},"voiceFileName":{"S":"call-on-weekday-morning.caf"}}},{"M":{"message":{"S":"紅葉さんの肩凝るねー"},"voiceFileName":{"S":"call-on-weekday-afternoon.caf"}}},{"M":{"message":{"S":"紅葉さんのボイス3"},"voiceFileName":{"S":"call-holiday-scheduled-alarm.caf"}}},{"M":{"message":{"S":"紅葉さんのボイス4"},"voiceFileName":{"S":"call-holiday-no-scheduled.caf"}}},{"M":{"message":{"S":"紅葉さんのボイス"},"voiceFileName":{"S":"call-small-talk.caf"}}}]},"expressions":{"M":{"normal":{"M":{"imageFileNames":{"L":[{"S":"normal.png"}]},"voiceFileNames":{"L":[{"S":"tap-general-1.caf"},{"S":"tap-general-2.caf"},{"S":"tap-general-3.caf"},{"S":"tap-general-4.caf"},{"S":"tap-general-5.caf"}]}}}}}}' \
     --region ap-northeast-1
 
+
+# news-table
+aws dynamodb create-table \
+    --endpoint-url $ENDPOINT_URL \
+    --table-name news-table \
+    --attribute-definitions AttributeName=newsID,AttributeType=S \
+    --key-schema AttributeName=newsID,KeyType=HASH \
+    --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
+    --region ap-northeast-1
+
 set +x

--- a/terraform/modules/dynamodb/main.tf
+++ b/terraform/modules/dynamodb/main.tf
@@ -82,3 +82,17 @@ resource "aws_dynamodb_table" "chara_table" {
     type = "S"
   }
 }
+
+resource "aws_dynamodb_table" "news_table" {
+  name           = "news-table"
+  hash_key       = "newsID"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 1
+  write_capacity = 1
+  stream_enabled = false
+
+  attribute {
+    name = "newsID"
+    type = "S"
+  }
+}


### PR DESCRIPTION
管理画面から **お知らせを即時配信** し、iOS アプリの**お知らせ一覧**（タイトル＋本文）に表示する。プッシュ通知なし・一覧/削除つきのシンプル構成。

## 決定事項（事前確認済み）
- **データ形**: タイトル＋本文（アプリ内表示）
- **配信範囲**: アプリ内お知らせ一覧のみ（プッシュ通知は送らない）
- **公開**: 即時公開のみ（作成・一覧・削除）

## 変更概要

**backend**
- `infrastructure`: `news-table` モデル（`database/news.go`）+ `ScanNews`/`InsertNews`/`DeleteNews`
- **api（公開）**: `GET /news/list` を実装（スタブ廃止、新しい順）
- **admin_api**: `GET /news` / `POST /news`（作成=配信）/ `DELETE /news/:newsID`
- `terraform`: `news-table` を追加。`local/createTable.sh` にも追加

**admin（Next.js）**
- お知らせ画面（作成フォーム + 配信済み一覧 + 削除）、サイドバー導線
- api client に `apiPost`/`apiDelete`、SWR フック、型を追加

**iOS**
- `News` を `{newsId, title, body, registeredAt}` に刷新
- `NewsRepository` + `APIRepository.getNewsList()`、`NewsListViewModel.fetchNews()` を実装
- `NewsRow`/`NewsListView` をタイトル＋本文のアプリ内表示に（Top のニュースボタンから既に導線あり）

## デプロイ手順（マージ前後）
1. **`terraform apply`（dev）で `news-table` を作成** ← 先にやる
2. PR マージ → Deploy(Dev) が api / admin_api / admin frontend を再デプロイ

IAM は既存ロールが `dynamodb:*` を持つため追加変更なし。

## 検証
- ✅ go build / vet / gofmt クリーン
- ✅ admin `npm run build` 成功（`/news` 静的生成）
- ✅ terraform validate / fmt OK
- ✅ iOS Develop ビルド成功、SwiftLint --strict 0 violations
- ⚠️ 実配信の疎通は `news-table` 作成 + デプロイ後に管理画面から確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)