### PR TITLE
ずんだもんを正式キャラとして追加（結衣/紅葉は維持）

### DIFF
--- a/application/infrastructure/aws_dynamodb_chara_test.go
+++ b/application/infrastructure/aws_dynamodb_chara_test.go
@@ -57,8 +57,8 @@ func TestGetCharaList(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// Assert
-	assert.Equal(t, len(charaList), 2)
+	// Assert (yui / momiji / zundamon の3体)
+	assert.Equal(t, len(charaList), 3)
 }
 
 func TestGetRandomChara(t *testing.T) {

--- a/ios/Charalarm/Resource/jp.zunko.zundamon/resource.json
+++ b/ios/Charalarm/Resource/jp.zunko.zundamon/resource.json
@@ -1,19 +1,19 @@
 {
-  "charaID" : "com.charalarm.yui",
-  "updatedAt": "2023-06-14",
+  "charaID" : "jp.zunko.zundamon",
+  "updatedAt": "2026-07-31",
   "expressions" : {
     "normal" : {
       "voiceFileNames" : [
-        "tap-11.caf",
-        "tap-12.caf",
-        "tap-13.caf",
-        "tap-14.caf",
-        "tap-15.caf",
-        "tap-16.caf",
-        "tap-17.caf",
-        "tap-18.caf",
-        "tap-19.caf",
-        "tap-20.caf"
+        "tap-01.caf",
+        "tap-02.caf",
+        "tap-03.caf",
+        "tap-04.caf",
+        "tap-05.caf",
+        "tap-06.caf",
+        "tap-07.caf",
+        "tap-08.caf",
+        "tap-09.caf",
+        "tap-10.caf"
       ],
       "imageFileNames" : [
         "normal-0.png",

--- a/local/createTable.sh
+++ b/local/createTable.sh
@@ -84,6 +84,12 @@ aws dynamodb put-item \
     --item '{"charaID":{"S":"com.senpu-ki-soft.momiji"},"enable":{"BOOL":true},"name":{"S":"紅葉"},"created_at":{"S":"2023-06-05"},"updated_at":{"S":"2023-06-14"},"description":{"S":"金髪紅眼の美少女。疲れ気味のあなたを心配して様々な癒しを、と考えている。その正体は幾百年を生きる鬼の末裔。あるいはあなたに恋慕を抱く彼女。ちょっと素直になりきれないものの、なんやかんやいってそばにいてくれる面倒見のいい少女。日々あなたの生活を見届けている。「わっち？　名は紅葉でありんす。主様の支えになれるよう、掃除でもみみかきでもなんでも言っておくんなんし。か、かわいい？　い、いきなりそんなこと言わないでおくんなんし！」"},"calls":{"L":[{"M":{"message":{"S":"紅葉さんの天気だね。"},"voiceFileName":{"S":"call-on-weekday-morning.caf"}}},{"M":{"message":{"S":"紅葉さんの肩凝るねー"},"voiceFileName":{"S":"call-on-weekday-afternoon.caf"}}},{"M":{"message":{"S":"紅葉さんのボイス3"},"voiceFileName":{"S":"call-holiday-scheduled-alarm.caf"}}},{"M":{"message":{"S":"紅葉さんのボイス4"},"voiceFileName":{"S":"call-holiday-no-scheduled.caf"}}},{"M":{"message":{"S":"紅葉さんのボイス"},"voiceFileName":{"S":"call-small-talk.caf"}}}]},"expressions":{"M":{"normal":{"M":{"imageFileNames":{"L":[{"S":"normal.png"}]},"voiceFileNames":{"L":[{"S":"tap-general-1.caf"},{"S":"tap-general-2.caf"},{"S":"tap-general-3.caf"},{"S":"tap-general-4.caf"},{"S":"tap-general-5.caf"}]}}}}}}' \
     --region ap-northeast-1
 
+aws dynamodb put-item \
+    --endpoint-url $ENDPOINT_URL \
+    --table-name chara-table \
+    --item '{"charaID":{"S":"jp.zunko.zundamon"},"enable":{"BOOL":true},"name":{"S":"ずんだもん"},"created_at":{"S":"2026-07-31"},"updated_at":{"S":"2026-07-31"},"description":{"S":"ずんだの妖精なのだ。ずんだもんと呼んでほしいのだ！VOICEVOXの声で、電話をかけるとおしゃべりもできるのだ〜。よろしくなのだ！"},"profiles":{"L":[{"M":{"title":{"S":"音声"},"name":{"S":"VOICEVOX:ずんだもん"},"url":{"S":"https://voicevox.hiroshiba.jp/"}}},{"M":{"title":{"S":"イラスト"},"name":{"S":"（イラスト作者を記入）"},"url":{"S":"https://zunko.jp/"}}}]},"calls":{"L":[{"M":{"message":{"S":"ずんだもんのモーニングコール1"},"voiceFileName":{"S":"call-01.caf"}}},{"M":{"message":{"S":"ずんだもんのモーニングコール2"},"voiceFileName":{"S":"call-02.caf"}}},{"M":{"message":{"S":"ずんだもんのモーニングコール3"},"voiceFileName":{"S":"call-03.caf"}}},{"M":{"message":{"S":"ずんだもんのモーニングコール4"},"voiceFileName":{"S":"call-04.caf"}}},{"M":{"message":{"S":"ずんだもんのモーニングコール5"},"voiceFileName":{"S":"call-05.caf"}}}]},"expressions":{"M":{"normal":{"M":{"imageFileNames":{"L":[{"S":"normal-0.png"},{"S":"smile-0.png"},{"S":"woo-0.png"},{"S":"woo-1.png"}]},"voiceFileNames":{"L":[{"S":"tap-01.caf"},{"S":"tap-02.caf"},{"S":"tap-03.caf"},{"S":"tap-04.caf"},{"S":"tap-05.caf"},{"S":"tap-06.caf"},{"S":"tap-07.caf"},{"S":"tap-08.caf"},{"S":"tap-09.caf"},{"S":"tap-10.caf"}]}}}}}}' \
+    --region ap-northeast-1
+
 
 # news-table
 aws dynamodb create-table \


### PR DESCRIPTION
ずんだもんはデフォルトキャラなのに **chara-table 未登録**で「キャラ一覧に出ない＝選べない」状態だった（デフォルトから他キャラに変えると戻せない）。既存キャラ（結衣/紅葉）を残したまま、**ずんだもんを正式にロスターへ追加**する。

## 変更（コード）
- **iOS バンドルの `resource.json` 修正**: `charaID` が誤って `com.charalarm.yui` になっていた 🐛 → `jp.zunko.zundamon`。併せて `expressions`/`updatedAt` を chara-table と一致（`tap-01..10`）
- **`local/createTable.sh`**: ずんだもんの chara-table put-item を追加（VOICEVOX クレジット付き）

## dev への反映（データ操作・git 管理外、実施済み）
- storage の zundamon アセットは既に dev S3 に配置済み（`aws s3 sync` 差分なし）
- **dev chara-table に put-item 済み** → `/chara/list` に3キャラ表示、`/chara/id/jp.zunko.zundamon` と画像/サムネ/自己紹介の配信（HTTP 200）を確認

## 検証
- ✅ dev `/chara/list` に ずんだもん(enable=true) 表示
- ✅ 詳細API・画像・サムネ・自己紹介 全て 200
- ✅ iOS Develop ビルド成功

## TODO（別途）
- プロフィールの**イラスト作者**を記入（今はプレースホルダ `（イラスト作者を記入）`）
- **prod chara-table への put-item**（dev ビッグバンのため今回は dev のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)