### PR TITLE
管理画面の書き込み(POST/DELETE)が届かない問題を修正

### DIFF
--- a/application/admin_api/main.go
+++ b/application/admin_api/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"net/http"
+	"os"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/takoikatakotako/charalarm/admin_api/handler"
@@ -8,6 +11,28 @@ import (
 	"github.com/takoikatakotako/charalarm/environment"
 	"github.com/takoikatakotako/charalarm/infrastructure"
 )
+
+// originVerifyMiddleware は CloudFront が注入する共有秘密ヘッダを検証する。
+// admin_api の Function URL は auth=NONE(公開)のため、生URLの直叩きを防ぐ。
+// ADMIN_ORIGIN_SECRET が未設定(ローカル開発等)の場合は検証をスキップする。
+func originVerifyMiddleware(secret string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// ヘルスチェックは素通し
+			if c.Path() == "/healthcheck" {
+				return next(c)
+			}
+			// 秘密が未設定なら検証しない(ローカル開発向け)
+			if secret == "" {
+				return next(c)
+			}
+			if c.Request().Header.Get("X-Origin-Verify") != secret {
+				return c.NoContent(http.StatusForbidden)
+			}
+			return next(c)
+		}
+	}
+}
 
 func main() {
 	env := environment.Environment{}
@@ -41,6 +66,7 @@ func main() {
 	e := echo.New()
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
+	e.Use(originVerifyMiddleware(os.Getenv("ADMIN_ORIGIN_SECRET")))
 
 	e.GET("/healthcheck", healthcheckHandler.HealthcheckGet)
 

--- a/terraform/environment/development/admin.tf
+++ b/terraform/environment/development/admin.tf
@@ -2,10 +2,11 @@
 # Admin API (Lambda)
 ##############################################################
 module "admin_api" {
-  source        = "../../modules/admin_api"
-  function_name = "${local.prefix}-admin-api"
-  image_uri     = "448049807848.dkr.ecr.ap-northeast-1.amazonaws.com/charalarm-admin-api"
-  image_tag     = "latest"
+  source                           = "../../modules/admin_api"
+  function_name                    = "${local.prefix}-admin-api"
+  image_uri                        = "448049807848.dkr.ecr.ap-northeast-1.amazonaws.com/charalarm-admin-api"
+  image_tag                        = "latest"
+  origin_secret_ssm_parameter_name = "/charalarm/dev/admin/basic-auth-password"
 }
 
 

--- a/terraform/modules/admin_api/main.tf
+++ b/terraform/modules/admin_api/main.tf
@@ -1,3 +1,9 @@
+# CloudFront から注入される共有秘密(= admin Basic 認証パスワードを流用)を
+# apply 時に読み、Lambda 環境変数へ渡す。生 Function URL の直叩き防止に使う。
+data "aws_ssm_parameter" "origin_secret" {
+  name = var.origin_secret_ssm_parameter_name
+}
+
 resource "aws_lambda_function" "admin_api_lambda_function" {
   function_name = var.function_name
   timeout       = 30
@@ -9,6 +15,7 @@ resource "aws_lambda_function" "admin_api_lambda_function" {
   environment {
     variables = {
       "CHARALARM_AWS_PROFILE" = "",
+      "ADMIN_ORIGIN_SECRET"   = data.aws_ssm_parameter.origin_secret.value,
     }
   }
 
@@ -18,8 +25,18 @@ resource "aws_lambda_function" "admin_api_lambda_function" {
   }
 }
 
-# OAC 経由で CloudFront から呼び出すため AWS_IAM 認証
+# OAC(SigV4)は POST のボディに署名できず Lambda URL が 403 を返すため、
+# 認証は NONE にし、CloudFront 関数が注入する共有秘密ヘッダを admin_api 側で検証する。
 resource "aws_lambda_function_url" "admin_api_lambda_function_url" {
   function_name      = aws_lambda_function.admin_api_lambda_function.function_name
-  authorization_type = "AWS_IAM"
+  authorization_type = "NONE"
+}
+
+# auth=NONE の Function URL を公開呼び出し可能にする(実際の保護は共有秘密ヘッダ)
+resource "aws_lambda_permission" "admin_api_function_url_public" {
+  statement_id           = "FunctionURLAllowPublicAccess"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.admin_api_lambda_function.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
 }

--- a/terraform/modules/admin_api/variables.tf
+++ b/terraform/modules/admin_api/variables.tf
@@ -9,3 +9,9 @@ variable "image_uri" {
 variable "image_tag" {
   type = string
 }
+
+# CloudFront が注入する共有秘密ヘッダの値を保持する SSM パラメータ名
+# (admin の Basic 認証パスワードを流用)。
+variable "origin_secret_ssm_parameter_name" {
+  type = string
+}

--- a/terraform/modules/admin_frontend/main.tf
+++ b/terraform/modules/admin_frontend/main.tf
@@ -37,13 +37,6 @@ resource "aws_cloudfront_origin_access_control" "admin_frontend" {
   signing_protocol                  = "sigv4"
 }
 
-resource "aws_cloudfront_origin_access_control" "admin_api" {
-  name                              = "${var.name_prefix}-admin-api"
-  origin_access_control_origin_type = "lambda"
-  signing_behavior                  = "always"
-  signing_protocol                  = "sigv4"
-}
-
 ##############################################################
 # CloudFront Functions (Basic 認証 + URI 書き換え)
 ##############################################################
@@ -97,8 +90,9 @@ resource "aws_cloudfront_function" "admin_api_auth_rewrite" {
           headers: { 'www-authenticate': { value: 'Basic realm="Admin"' } },
         };
       }
-      // OAC SigV4 署名と競合するため Basic 認証通過後に Authorization を削除
       delete request.headers.authorization;
+      // auth=NONE の admin_api を生URL直叩きから守るため共有秘密ヘッダを注入
+      request.headers['x-origin-verify'] = { value: '${data.aws_ssm_parameter.basic_auth_password.value}' };
       request.uri = request.uri.replace(/^\/api/, '');
       if (request.uri === '') {
         request.uri = '/';
@@ -119,9 +113,8 @@ resource "aws_cloudfront_distribution" "admin" {
   }
 
   origin {
-    domain_name              = local.api_origin_domain
-    origin_id                = "lambda-admin-api"
-    origin_access_control_id = aws_cloudfront_origin_access_control.admin_api.id
+    domain_name = local.api_origin_domain
+    origin_id   = "lambda-admin-api"
 
     custom_origin_config {
       http_port              = 80
@@ -216,18 +209,6 @@ resource "aws_route53_record" "admin" {
     name                   = aws_cloudfront_distribution.admin.domain_name
     zone_id                = local.cloudfront_zone_id
   }
-}
-
-##############################################################
-# Lambda Permission (CloudFront から OAC で呼び出すため)
-##############################################################
-resource "aws_lambda_permission" "admin_cloudfront" {
-  statement_id           = "AllowCloudFrontInvoke"
-  action                 = "lambda:InvokeFunctionUrl"
-  function_name          = var.admin_api_function_name
-  principal              = "cloudfront.amazonaws.com"
-  function_url_auth_type = "AWS_IAM"
-  source_arn             = aws_cloudfront_distribution.admin.arn
 }
 
 ##############################################################


### PR DESCRIPTION
## 症状
管理画面（お知らせ配信フォーム等）から**投稿・削除ができない**。GET（一覧表示）は動くのに、POST するとブラウザに管理画面のHTMLが返る（＝配信されない）。

## 原因
admin_api の Lambda Function URL を **OAC（AWS_IAM 署名）**で保護していたが、**CloudFront OAC は POST のリクエストボディに署名しない** → Lambda URL が署名不一致で 403 → CloudFront の `403 → /index.html` フォールバック（SPA用）が握りつぶして 200+HTML に化ける。**POST/DELETE は admin_api に到達すらしていなかった**（admin_api ログで確認：GET は届くが POST は無し）。

## 対応
Function URL を **auth=NONE** にし、**CloudFront 関数が注入する共有秘密ヘッダ（`X-Origin-Verify`）を admin_api が検証**して生URLの直叩きを防ぐ（秘密は既存の admin Basic 認証パスワードを流用、新規シークレット無し）。

- **admin_api**: `originVerifyMiddleware` を追加。`ADMIN_ORIGIN_SECRET` と `X-Origin-Verify` を突合（未設定時はローカル開発向けに検証スキップ）
- **modules/admin_api**: Function URL を NONE 化、公開 permission 追加、`ADMIN_ORIGIN_SECRET` を SSM（basic-auth-password）から env に注入
- **modules/admin_frontend**: admin_api の OAC 撤去、CloudFront 関数で `X-Origin-Verify` を注入
- **environment/development**: `origin_secret_ssm_parameter_name` を配線

## 検証
- ✅ go build / gofmt、terraform validate / fmt
- staging/prod は admin 未使用（dev のみ）

## デプロイ順（重要）
1. **マージ** → Deploy(Dev) が admin_api 新イメージ（ミドルウェア入り）を反映
2. **terraform apply（dev）** で auth=NONE + 秘密ヘッダ + OAC撤去
3. 管理パネルから投稿テスト → 通ることを確認

（順序：マージ先行。apply 先行だと新イメージ反映までの間 生URLが無防備になるため）

## 補足
- 共有秘密に Basic 認証パスワードを流用。パスワードに `'` や `\` を含めると CloudFront 関数のJS文字列が壊れるため、英数字推奨
- 恒久的には admin_api も `ssm://` 実行時解決に寄せてもよい（今回は既存 admin_frontend と同じ apply 時 bake で統一）

🤖 Generated with [Claude Code](https://claude.com/claude-code)