### PR TITLE
admin_api に news-table への書き込み権限を付与

### DIFF
--- a/terraform/modules/admin_api/iam.tf
+++ b/terraform/modules/admin_api/iam.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "admin_api_lambda_function_role_policy_document" 
     resources = ["*"]
   }
 
-  # 管理画面は読み取りのみ。書き込みが必要になったら拡張する
+  # 参照は全テーブル読み取り可
   statement {
     effect = "Allow"
     actions = [
@@ -64,6 +64,18 @@ data "aws_iam_policy_document" "admin_api_lambda_function_role_policy_document" 
       "dynamodb:Query",
     ]
     resources = ["*"]
+  }
+
+  # お知らせの作成・削除は news-table のみ書き込み可(最小権限)
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:ap-northeast-1:${local.account_id}:table/news-table"
+    ]
   }
 }
 


### PR DESCRIPTION
#229（管理画面の書き込み経路修正）に続く追い修正。POST がルーティングされるようになったが、admin_api ロールが **読み取り専用**だったため `dynamodb:PutItem` が AccessDenied になっていた。

- `modules/admin_api/iam.tf`: **news-table のみ** `PutItem`/`DeleteItem` を許可（最小権限）。users/alarms は従来どおり読み取りのみ

## 検証（dev 適用済み）
- ✅ 管理パネル経路 `POST /api/news` → **HTTP 200**（お知らせ作成成功）
- ✅ 生 Function URL 直叩き（秘密ヘッダ無し）→ **HTTP 403**（直叩き防御OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)