### PR TITLE
管理画面にキャラクター確認画面を追加（読み取り）

### DIFF
--- a/admin/src/app/chara/page.tsx
+++ b/admin/src/app/chara/page.tsx
@@ -1,0 +1,5 @@
+import { CharaPage } from "@/components/chara/chara-page";
+
+export default function Page() {
+  return <CharaPage />;
+}

--- a/admin/src/components/chara/chara-page.tsx
+++ b/admin/src/components/chara/chara-page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCharas } from "@/hooks/use-chara";
+import type { Chara } from "@/lib/api/types";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+function CharaCard({ chara }: { chara: Chara }) {
+  const expressionNames = Object.keys(chara.expressions);
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CardTitle>{chara.name}</CardTitle>
+          <Badge variant={chara.enable ? "default" : "secondary"}>
+            {chara.enable ? "有効" : "無効"}
+          </Badge>
+        </div>
+        <p className="font-mono text-xs text-muted-foreground">
+          {chara.charaID}
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <p className="whitespace-pre-wrap break-words">{chara.description}</p>
+
+        {chara.profiles.length > 0 && (
+          <div className="space-y-1">
+            <p className="font-medium">クレジット</p>
+            <ul className="space-y-0.5 text-muted-foreground">
+              {chara.profiles.map((p, i) => (
+                <li key={i}>
+                  <span className="text-foreground">{p.title}</span>：{p.name}
+                  {p.url && (
+                    <a
+                      href={p.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="ml-2 underline hover:text-foreground"
+                    >
+                      link
+                    </a>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-x-6 gap-y-1 text-muted-foreground">
+          <span>コール: {chara.calls.length}件</span>
+          <span>
+            表情: {expressionNames.length > 0 ? expressionNames.join(", ") : "なし"}
+          </span>
+        </div>
+
+        <p className="text-xs text-muted-foreground">更新: {chara.updatedAt}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CharaPage() {
+  const { data, error, isLoading } = useCharas();
+  const charas = data?.charas ?? [];
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <h1 className="text-2xl font-bold">キャラクター</h1>
+
+      {isLoading && <p className="text-muted-foreground">読み込み中...</p>}
+      {error && <p className="text-destructive">エラーが発生しました</p>}
+
+      {data && charas.length === 0 && (
+        <p className="text-muted-foreground">キャラクターがいません</p>
+      )}
+
+      <div className="space-y-4">
+        {charas.map((chara) => (
+          <CharaCard key={chara.charaID} chara={chara} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/admin/src/components/layout/sidebar.tsx
+++ b/admin/src/components/layout/sidebar.tsx
@@ -2,11 +2,12 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Users, Megaphone } from "lucide-react";
+import { Users, Megaphone, Smile } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const navigation = [
   { name: "ユーザー", href: "/users", icon: Users },
+  { name: "キャラクター", href: "/chara", icon: Smile },
   { name: "お知らせ", href: "/news", icon: Megaphone },
 ];
 

--- a/admin/src/hooks/use-chara.ts
+++ b/admin/src/hooks/use-chara.ts
@@ -1,0 +1,7 @@
+import useSWR from "swr";
+import { fetchCharas } from "@/lib/api/chara";
+import type { CharaListResponse } from "@/lib/api/types";
+
+export function useCharas() {
+  return useSWR<CharaListResponse>("/chara", fetchCharas);
+}

--- a/admin/src/lib/api/chara.ts
+++ b/admin/src/lib/api/chara.ts
@@ -1,0 +1,10 @@
+import { apiGet } from "@/lib/api/client";
+import type { CharaListResponse, Chara } from "@/lib/api/types";
+
+export async function fetchCharas(): Promise<CharaListResponse> {
+  return apiGet<CharaListResponse>("/chara");
+}
+
+export async function fetchChara(charaID: string): Promise<Chara> {
+  return apiGet<Chara>(`/chara/${encodeURIComponent(charaID)}`);
+}

--- a/admin/src/lib/api/types.ts
+++ b/admin/src/lib/api/types.ts
@@ -56,3 +56,35 @@ export interface News {
 export interface NewsListResponse {
   news: News[];
 }
+
+export interface CharaProfile {
+  title: string;
+  name: string;
+  url: string;
+}
+
+export interface CharaCall {
+  message: string;
+  voiceFileName: string;
+}
+
+export interface CharaExpression {
+  imageFileNames: string[];
+  voiceFileNames: string[];
+}
+
+export interface Chara {
+  charaID: string;
+  enable: boolean;
+  createdAt: string;
+  updatedAt: string;
+  name: string;
+  description: string;
+  profiles: CharaProfile[];
+  calls: CharaCall[];
+  expressions: Record<string, CharaExpression>;
+}
+
+export interface CharaListResponse {
+  charas: Chara[];
+}

--- a/application/admin_api/handler/chara.go
+++ b/application/admin_api/handler/chara.go
@@ -1,0 +1,103 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takoikatakotako/charalarm/admin_api/service"
+	"github.com/takoikatakotako/charalarm/admin_api/service/output"
+)
+
+type Chara struct {
+	Service service.Chara
+}
+
+type charaProfileResponse struct {
+	Title string `json:"title"`
+	Name  string `json:"name"`
+	URL   string `json:"url"`
+}
+
+type charaCallResponse struct {
+	Message       string `json:"message"`
+	VoiceFileName string `json:"voiceFileName"`
+}
+
+type charaExpressionResponse struct {
+	ImageFileNames []string `json:"imageFileNames"`
+	VoiceFileNames []string `json:"voiceFileNames"`
+}
+
+type charaResponse struct {
+	CharaID     string                             `json:"charaID"`
+	Enable      bool                               `json:"enable"`
+	CreatedAt   string                             `json:"createdAt"`
+	UpdatedAt   string                             `json:"updatedAt"`
+	Name        string                             `json:"name"`
+	Description string                             `json:"description"`
+	Profiles    []charaProfileResponse             `json:"profiles"`
+	Calls       []charaCallResponse                `json:"calls"`
+	Expressions map[string]charaExpressionResponse `json:"expressions"`
+}
+
+type charaListResponse struct {
+	Charas []charaResponse `json:"charas"`
+}
+
+func (h *Chara) CharaListGet(c echo.Context) error {
+	charaList, err := h.Service.ScanCharas()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, newErrorResponse("scan_charas_failed", err.Error()))
+	}
+
+	res := make([]charaResponse, 0, len(charaList))
+	for _, chara := range charaList {
+		res = append(res, toCharaResponse(chara))
+	}
+	return c.JSON(http.StatusOK, charaListResponse{Charas: res})
+}
+
+func (h *Chara) CharaGet(c echo.Context) error {
+	charaID := c.Param("charaID")
+	if charaID == "" {
+		return c.JSON(http.StatusBadRequest, newErrorResponse("invalid_chara_id", "charaID is required"))
+	}
+
+	chara, err := h.Service.GetChara(charaID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, newErrorResponse("chara_not_found", err.Error()))
+	}
+	return c.JSON(http.StatusOK, toCharaResponse(chara))
+}
+
+func toCharaResponse(c output.Chara) charaResponse {
+	profiles := make([]charaProfileResponse, 0, len(c.Profiles))
+	for _, p := range c.Profiles {
+		profiles = append(profiles, charaProfileResponse{Title: p.Title, Name: p.Name, URL: p.URL})
+	}
+
+	calls := make([]charaCallResponse, 0, len(c.Calls))
+	for _, call := range c.Calls {
+		calls = append(calls, charaCallResponse{Message: call.Message, VoiceFileName: call.VoiceFileName})
+	}
+
+	expressions := make(map[string]charaExpressionResponse, len(c.Expressions))
+	for name, e := range c.Expressions {
+		expressions[name] = charaExpressionResponse{
+			ImageFileNames: e.ImageFileNames,
+			VoiceFileNames: e.VoiceFileNames,
+		}
+	}
+
+	return charaResponse{
+		CharaID:     c.CharaID,
+		Enable:      c.Enable,
+		CreatedAt:   c.CreatedAt,
+		UpdatedAt:   c.UpdatedAt,
+		Name:        c.Name,
+		Description: c.Description,
+		Profiles:    profiles,
+		Calls:       calls,
+		Expressions: expressions,
+	}
+}

--- a/application/admin_api/main.go
+++ b/application/admin_api/main.go
@@ -51,6 +51,9 @@ func main() {
 	newsService := service.News{
 		AWS: awsRepository,
 	}
+	charaService := service.Chara{
+		AWS: awsRepository,
+	}
 
 	healthcheckHandler := handler.Healthcheck{}
 	userHandler := handler.User{
@@ -61,6 +64,9 @@ func main() {
 	}
 	newsHandler := handler.News{
 		Service: newsService,
+	}
+	charaHandler := handler.Chara{
+		Service: charaService,
 	}
 
 	e := echo.New()
@@ -77,6 +83,9 @@ func main() {
 	e.GET("/news", newsHandler.NewsListGet)
 	e.POST("/news", newsHandler.NewsPost)
 	e.DELETE("/news/:newsID", newsHandler.NewsDelete)
+
+	e.GET("/chara", charaHandler.CharaListGet)
+	e.GET("/chara/:charaID", charaHandler.CharaGet)
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/application/admin_api/service/chara.go
+++ b/application/admin_api/service/chara.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"sort"
+
+	"github.com/takoikatakotako/charalarm/admin_api/service/output"
+	"github.com/takoikatakotako/charalarm/infrastructure"
+	"github.com/takoikatakotako/charalarm/infrastructure/database"
+)
+
+type Chara struct {
+	AWS infrastructure.AWS
+}
+
+// ScanCharas キャラ一覧を charaID 昇順で返す(enable の有無に関わらず全件)。
+func (s *Chara) ScanCharas() ([]output.Chara, error) {
+	charaList, err := s.AWS.GetCharaList()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]output.Chara, 0, len(charaList))
+	for _, c := range charaList {
+		out = append(out, toCharaOutput(c))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CharaID < out[j].CharaID
+	})
+	return out, nil
+}
+
+// GetChara 指定 charaID のキャラを返す。
+func (s *Chara) GetChara(charaID string) (output.Chara, error) {
+	chara, err := s.AWS.GetChara(charaID)
+	if err != nil {
+		return output.Chara{}, err
+	}
+	return toCharaOutput(chara), nil
+}
+
+func toCharaOutput(c database.Chara) output.Chara {
+	profiles := make([]output.CharaProfile, 0, len(c.Profiles))
+	for _, p := range c.Profiles {
+		profiles = append(profiles, output.CharaProfile{Title: p.Title, Name: p.Name, URL: p.URL})
+	}
+
+	calls := make([]output.CharaCall, 0, len(c.Calls))
+	for _, call := range c.Calls {
+		calls = append(calls, output.CharaCall{Message: call.Message, VoiceFileName: call.VoiceFileName})
+	}
+
+	expressions := make(map[string]output.CharaExpression, len(c.Expressions))
+	for name, e := range c.Expressions {
+		expressions[name] = output.CharaExpression{
+			ImageFileNames: e.ImageFileNames,
+			VoiceFileNames: e.VoiceFileNames,
+		}
+	}
+
+	return output.Chara{
+		CharaID:     c.CharaID,
+		Enable:      c.Enable,
+		CreatedAt:   c.CreatedAt,
+		UpdatedAt:   c.UpdatedAd,
+		Name:        c.Name,
+		Description: c.Description,
+		Profiles:    profiles,
+		Calls:       calls,
+		Expressions: expressions,
+	}
+}

--- a/application/admin_api/service/output/chara.go
+++ b/application/admin_api/service/output/chara.go
@@ -1,0 +1,29 @@
+package output
+
+type CharaProfile struct {
+	Title string
+	Name  string
+	URL   string
+}
+
+type CharaCall struct {
+	Message       string
+	VoiceFileName string
+}
+
+type CharaExpression struct {
+	ImageFileNames []string
+	VoiceFileNames []string
+}
+
+type Chara struct {
+	CharaID     string
+	Enable      bool
+	CreatedAt   string
+	UpdatedAt   string
+	Name        string
+	Description string
+	Profiles    []CharaProfile
+	Calls       []CharaCall
+	Expressions map[string]CharaExpression
+}


### PR DESCRIPTION
Closes #234

管理画面でキャラクター（結衣/紅葉/ずんだもん）の登録内容を確認できるようにする。まずは**閲覧のみ**（編集は別issue #236）。

## 変更
- **admin_api**: `GET /chara`（一覧）/ `GET /chara/:charaID`（詳細）。infrastructure の `GetCharaList`/`GetChara` を利用。既存の読み取りIAMで足りる（追加なし）
- **admin（Next.js）**: 「キャラクター」画面 — 名前・charaID・有効/無効バッジ・説明・クレジット・コール数・表情。サイドバー導線追加

## 検証
- ✅ go build / vet / gofmt
- ✅ admin `npm run build`（`/chara` 生成）
- デプロイ後、パネルで3キャラが見えることを確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)