### PR TITLE
Go を 1.25 に揃えてイメージビルド失敗を修正

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Create DynamoDB tables
         run: |

--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     # DynamoDBテーブル作成
     - name: Create DynamoDB tables

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ```
 charalarm/
-├── application/     # バックエンド (Go 1.24, Lambda)
+├── application/     # バックエンド (Go 1.25, Lambda)
 │   ├── api/         # REST API (Echo)
 │   ├── admin_api/   # 管理画面用 API (Echo, CloudFront 配下)
 │   ├── batch/       # 毎分実行バッチ (EventBridge)
@@ -24,7 +24,7 @@ charalarm/
 ## 技術スタック
 
 **iOS**: Swift, SwiftUI, Combine, Firebase, Datadog, CallKit
-**Backend**: Go 1.24, Echo v4, AWS SDK v2
+**Backend**: Go 1.25, Echo v4, AWS SDK v2
 **Infra**: Lambda, DynamoDB, SQS, SNS, S3, CloudFront, API Gateway, EventBridge
 **IaC**: Terraform
 **CI/CD**: GitHub Actions (OIDC認証)

--- a/application/admin_api/Dockerfile
+++ b/application/admin_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine3.21 AS builder
+FROM golang:1.25-alpine3.21 AS builder
 WORKDIR /app
 COPY . .
 RUN go mod tidy

--- a/application/api/Dockerfile
+++ b/application/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine3.21 AS builder
+FROM golang:1.25-alpine3.21 AS builder
 WORKDIR /app
 COPY . .
 RUN go mod tidy

--- a/application/batch/Dockerfile
+++ b/application/batch/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine3.21 AS builder
+FROM golang:1.25-alpine3.21 AS builder
 WORKDIR /app
 COPY . .
 RUN go mod tidy

--- a/application/worker/Dockerfile
+++ b/application/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine3.21 AS builder
+FROM golang:1.25-alpine3.21 AS builder
 WORKDIR /app
 COPY . .
 RUN go mod tidy


### PR DESCRIPTION
## 症状
Deploy(Dev) の **api/admin_api/batch/worker のイメージビルドが全滅**（#240以降）。そのため #240（crypto）/#241（npm）/#242（会話キャラ人格）の**バックエンドが dev に未反映**（admin frontend だけデプロイされていた）。

## 原因
#240 の `golang.org/x/crypto` 更新に伴う `go mod tidy` で **go.mod の go ディレクティブが 1.25.0 に上がった**が、Dockerfile は `golang:1.24.0` のまま。Docker ビルド（`GOTOOLCHAIN=local`）で:
```
go: go.mod requires go >= 1.25.0 (running go 1.24.0; GOTOOLCHAIN=local)
```
※ CI の `Test Application` は setup-go の toolchain 自動DLで通っていたため気づけなかった。

## 対応
Go を 1.25 に揃える:
- Dockerfile 4つ: `golang:1.24.0-alpine3.21` → `golang:1.25-alpine3.21`（タグ実在確認済み）
- CI（setup-go）: `1.24` → `1.25`
- CLAUDE.md: Go 1.24 → 1.25

## マージ後
Deploy(Dev) が成功すれば、#242（会話キャラ人格のサーバ側管理）を含むバックエンドが dev に反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)